### PR TITLE
feat: Phase 2 — iteration mode (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ stop it.
 
 ## Status
 
-Early MVP. Phase 1 implemented:
+Early MVP. Phase 1 + 2 implemented:
 
 - `continuous` mode end-to-end with the Claude Code agent (#2)
+- `iteration` mode: per-task branch + PR from a `tasks.md` backlog (#3)
 - LLM-generated commit messages (#4)
 - State persisted under `~/.local/state/kobito/` (#6)
 - Real-time log passthrough with a status bar (#5)
@@ -20,7 +21,6 @@ Early MVP. Phase 1 implemented:
 
 Not yet implemented:
 
-- `iteration` mode + `tasks.md` (#3)
 - Preset system (#7)
 - Codex agent backend (#9)
 
@@ -31,21 +31,60 @@ cargo install --path .
 ```
 
 Requires the [`claude`](https://github.com/anthropics/claude-code) CLI on
-`PATH`.
+`PATH`. Iteration mode additionally requires the [`gh`](https://cli.github.com/)
+CLI authenticated for the project's remote.
 
 ## Usage
+
+### continuous
+
+Pursue a single open-ended goal on one working branch:
 
 ```sh
 # from inside a clean git repo
 kobito continuous --prompt "Increase test coverage in src/"
 ```
 
-Options:
+### iteration
+
+Consume a backlog of small tasks, one branch + PR per task:
+
+```sh
+# seed the backlog (committed to the project)
+cat > .kobito/tasks.md <<'EOF'
+- [ ] Add /healthz endpoint
+- [ ] Wire Prometheus metrics middleware
+- [ ] Document the new endpoints in README
+EOF
+
+kobito iteration
+```
+
+Or point at an explicit backlog file:
+
+```sh
+kobito iteration --backlog ./tasks.md
+```
+
+The first run copies `.kobito/tasks.md` (or the file passed via `--backlog`)
+into the state directory. From then on the state copy is the source of truth —
+edit it through:
+
+```sh
+kobito tasks edit
+```
+
+For each unchecked item, kobito branches off the starting branch as
+`kobito/task-<n>-<slug>`, iterates until the agent emits `TASK_COMPLETE`,
+runs `gh pr create`, and marks the line `[x]` in the state copy.
+
+### Common options
 
 | flag                | default   | meaning                                     |
 | ------------------- | --------- | ------------------------------------------- |
-| `--prompt`, `-p`    | required  | the goal to pursue                          |
-| `--max-iterations`  | `50`      | hard cap on iterations                      |
+| `--prompt`, `-p`    | required (continuous) | the goal to pursue              |
+| `--backlog`         | optional (iteration)  | path to a tasks.md backlog      |
+| `--max-iterations`  | `50` / `30` | hard cap on iterations (per task in iteration mode) |
 | `--max-failures`    | `3`       | give up after N consecutive failures        |
 | `--language`        | `en`      | output language (also reads `kobito.toml`)  |
 | `--agent`           | `claude`  | backend agent (only `claude` for now)       |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,8 +68,28 @@ pub async fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
         Command::Continuous(args) => runner::run_continuous(args).await,
         Command::Ls => crate::state::list_projects(),
-        Command::Log { .. } | Command::Resume { .. } | Command::Tasks { .. } => {
-            bail!("not yet implemented — tracked in #3 / #6")
+        Command::Tasks {
+            action: TasksAction::Edit,
+        } => edit_tasks(),
+        Command::Log { .. } | Command::Resume { .. } => {
+            bail!("not yet implemented — tracked in #6")
         }
     }
+}
+
+fn edit_tasks() -> Result<()> {
+    let repo = crate::git::repo_root()?;
+    let remote = crate::git::remote_url(&repo);
+    let id = crate::state::project_id(&repo, remote.as_deref());
+    let project = crate::state::project_paths(id)?;
+    let path = crate::state::seed_tasks_if_needed(&project, &repo)?;
+    let editor = std::env::var("EDITOR")
+        .or_else(|_| std::env::var("VISUAL"))
+        .unwrap_or_else(|_| "vi".into());
+    let status = std::process::Command::new(editor).arg(&path).status()?;
+    if !status.success() {
+        bail!("editor exited with {status}");
+    }
+    println!("{}", path.display());
+    Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,8 @@
 use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
-use crate::runner;
+use crate::{iteration, runner};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -18,6 +19,8 @@ pub struct Cli {
 pub enum Command {
     /// Run a never-ending goal on a single branch with many commits.
     Continuous(ContinuousArgs),
+    /// Consume a tasks.md backlog, one branch + PR per task.
+    Iteration(IterationArgs),
     /// List all known projects with their last run.
     Ls,
     /// Replay the last run's log for a project.
@@ -35,6 +38,34 @@ pub enum Command {
 pub enum TasksAction {
     /// Open $EDITOR on the state copy of tasks.md.
     Edit,
+}
+
+#[derive(Parser, Debug)]
+pub struct IterationArgs {
+    /// Path to a tasks.md backlog. If omitted, uses the state copy
+    /// (seeded from .kobito/tasks.md on first run).
+    #[arg(long)]
+    pub backlog: Option<PathBuf>,
+
+    /// Maximum iterations per task before giving up.
+    #[arg(long, default_value_t = 30)]
+    pub max_iterations: u32,
+
+    /// Maximum consecutive failures per task before skipping.
+    #[arg(long, default_value_t = 3)]
+    pub max_failures: u32,
+
+    /// Output language for code, comments, commit messages.
+    #[arg(long)]
+    pub language: Option<String>,
+
+    /// Agent backend (currently only `claude`).
+    #[arg(long, default_value = "claude")]
+    pub agent: String,
+
+    /// Skip the clean-tree check (dangerous).
+    #[arg(long)]
+    pub allow_dirty: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -67,6 +98,7 @@ pub struct ContinuousArgs {
 pub async fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
         Command::Continuous(args) => runner::run_continuous(args).await,
+        Command::Iteration(args) => iteration::run(args).await,
         Command::Ls => crate::state::list_projects(),
         Command::Tasks {
             action: TasksAction::Edit,

--- a/src/git.rs
+++ b/src/git.rs
@@ -54,6 +54,10 @@ pub fn create_and_checkout(repo: &Path, branch: &str) -> Result<()> {
     run(repo, &["checkout", "-b", branch])
 }
 
+pub fn checkout(repo: &Path, branch: &str) -> Result<()> {
+    run(repo, &["checkout", branch])
+}
+
 pub fn stage_all(repo: &Path) -> Result<()> {
     run(repo, &["add", "-A"])
 }

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -1,0 +1,197 @@
+use anyhow::{Result, bail};
+use std::path::Path;
+use std::process::Command as StdCommand;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use crate::cli::IterationArgs;
+use crate::{agent, commit, config, git, logger::LogSink, prompt, state, tasks::Backlog, ui};
+
+pub async fn run(args: IterationArgs) -> Result<()> {
+    let repo = git::repo_root()?;
+    if !args.allow_dirty {
+        git::ensure_clean(&repo)?;
+    }
+
+    let project_cfg = config::load(&repo)?;
+    let language = config::resolve_language(args.language.as_deref(), &project_cfg);
+
+    let remote = git::remote_url(&repo);
+    let id = state::project_id(&repo, remote.as_deref());
+    let project = state::project_paths(id)?;
+
+    let tasks_state_path = state::tasks_path(&project);
+    if let Some(backlog_arg) = &args.backlog {
+        let body = std::fs::read_to_string(backlog_arg)?;
+        std::fs::write(&tasks_state_path, body)?;
+    } else {
+        state::seed_tasks_if_needed(&project, &repo)?;
+    }
+
+    let mut backlog = Backlog::from_file(&tasks_state_path)?;
+    let pending: Vec<(usize, String)> = backlog
+        .pending()
+        .iter()
+        .map(|t| (t.line_no, t.body.clone()))
+        .collect();
+
+    if pending.is_empty() {
+        println!("no pending tasks in {}", tasks_state_path.display());
+        return Ok(());
+    }
+
+    let starting_branch = git::current_branch(&repo)?;
+    let bar = ui::make_status_bar();
+
+    let cancelled = Arc::new(AtomicBool::new(false));
+    {
+        let f = cancelled.clone();
+        let _ = ctrlc::set_handler(move || f.store(true, Ordering::SeqCst));
+    }
+
+    let (agents_md, claude_md) = prompt::read_repo_docs(&repo);
+
+    for (n, (line_no, body)) in pending.iter().enumerate() {
+        if cancelled.load(Ordering::SeqCst) {
+            break;
+        }
+        let task_idx = n + 1;
+        let slug = slug::slugify(body).chars().take(40).collect::<String>();
+        let branch = format!("kobito/task-{task_idx}-{slug}");
+
+        if let Err(e) = git::checkout(&repo, &starting_branch) {
+            bar.println(format!("✗ failed to return to {starting_branch}: {e}"));
+            continue;
+        }
+        if let Err(e) = git::create_and_checkout(&repo, &branch) {
+            bar.println(format!("✗ branch create failed: {e}; skipping task: {body}"));
+            continue;
+        }
+
+        let run_dirs = state::new_run(project.clone())?;
+        let sink = LogSink::open(&run_dirs.log_file, Some(bar.clone()))?;
+        sink.note(&format!(
+            "=== task {}/{}: {} ===",
+            task_idx,
+            pending.len(),
+            body
+        ));
+
+        let started = Instant::now();
+        let mut consecutive_failures = 0u32;
+        let mut completed = false;
+
+        for iteration in 1..=args.max_iterations {
+            if cancelled.load(Ordering::SeqCst) {
+                break;
+            }
+            ui::set_status(
+                &bar,
+                iteration,
+                started.elapsed(),
+                consecutive_failures,
+                &format!("task {}/{}", task_idx, pending.len()),
+            );
+            let parts = prompt::PromptParts {
+                agents_md: agents_md.clone(),
+                claude_md: claude_md.clone(),
+                language: language.clone(),
+                goal: body.clone(),
+                iteration,
+                notes: None,
+            };
+            let prompt_body = prompt::build_task_prompt(&parts, &args.agent, body);
+            prompt::save_prompt(&run_dirs.prompts_dir, iteration, &prompt_body)?;
+
+            match agent::invoke_claude(&repo, &prompt_body, &sink).await {
+                Ok(out) => {
+                    consecutive_failures = 0;
+                    git::stage_all(&repo)?;
+                    if git::has_staged_changes(&repo)? {
+                        let diff = git::diff_staged(&repo)?;
+                        let style = git::recent_commit_messages(&repo, 20).unwrap_or_default();
+                        let msg = commit::generate_message(&repo, &diff, body, &style, &language)
+                            .await?;
+                        git::commit(&repo, &msg)?;
+                        sink.note(&format!(
+                            "✓ committed: {}",
+                            msg.lines().next().unwrap_or("")
+                        ));
+                    } else {
+                        sink.note("no diff this iteration");
+                    }
+                    if out.stdout.contains("TASK_COMPLETE") {
+                        sink.note("agent reported TASK_COMPLETE");
+                        completed = true;
+                        break;
+                    }
+                }
+                Err(e) => {
+                    consecutive_failures += 1;
+                    sink.note(&format!("✗ failed: {e}"));
+                    git::reset_hard(&repo).ok();
+                    if consecutive_failures >= args.max_failures {
+                        sink.note("giving up on this task");
+                        break;
+                    }
+                    let backoff =
+                        std::time::Duration::from_secs(2u64.pow(consecutive_failures));
+                    tokio::time::sleep(backoff).await;
+                }
+            }
+        }
+
+        if completed {
+            match push_and_open_pr(&repo, &branch, body, &starting_branch).await {
+                Ok(url) => {
+                    sink.note(&format!("✓ PR: {url}"));
+                    backlog.mark_completed(*line_no);
+                    backlog.write(&tasks_state_path)?;
+                }
+                Err(e) => {
+                    sink.note(&format!("✗ PR creation failed: {e}"));
+                }
+            }
+        } else {
+            sink.note(&format!(
+                "task did not complete; leaving branch {branch} for inspection"
+            ));
+        }
+
+        git::checkout(&repo, &starting_branch).ok();
+    }
+
+    bar.finish_and_clear();
+    println!("done — backlog state: {}", tasks_state_path.display());
+    Ok(())
+}
+
+async fn push_and_open_pr(repo: &Path, branch: &str, title: &str, base: &str) -> Result<String> {
+    let push = StdCommand::new("git")
+        .current_dir(repo)
+        .args(["push", "-u", "origin", branch])
+        .output()?;
+    if !push.status.success() {
+        bail!(
+            "git push failed: {}",
+            String::from_utf8_lossy(&push.stderr)
+        );
+    }
+
+    let pr_body = format!("Automated PR generated by kobito.\n\nTask: {title}\n");
+    let pr = StdCommand::new("gh")
+        .current_dir(repo)
+        .args([
+            "pr", "create", "--base", base, "--head", branch, "--title", title, "--body",
+            &pr_body,
+        ])
+        .output()?;
+    if !pr.status.success() {
+        bail!(
+            "gh pr create failed — is the `gh` CLI installed and authenticated? {}",
+            String::from_utf8_lossy(&pr.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&pr.stdout).trim().to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod logger;
 mod prompt;
 mod runner;
 mod state;
+mod tasks;
 mod ui;
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod cli;
 mod commit;
 mod config;
 mod git;
+mod iteration;
 mod logger;
 mod prompt;
 mod runner;

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -62,6 +62,44 @@ pub fn build_iteration_prompt(parts: &PromptParts, agent: &str) -> String {
     out
 }
 
+pub fn build_task_prompt(parts: &PromptParts, agent: &str, task_body: &str) -> String {
+    let mut out = String::new();
+
+    out.push_str(&format!(
+        "# Project conventions\n\nOutput all code, comments, and commit messages in {}.\n\n",
+        parts.language
+    ));
+
+    if let Some(md) = &parts.agents_md {
+        out.push_str("## AGENTS.md\n\n");
+        out.push_str(md.trim());
+        out.push_str("\n\n");
+    }
+
+    if agent != "claude" {
+        if let Some(md) = &parts.claude_md {
+            out.push_str("## CLAUDE.md\n\n");
+            out.push_str(md.trim());
+            out.push_str("\n\n");
+        }
+    }
+
+    out.push_str(&format!(
+        "## Single task\n\n{}\n\n## Iteration {}\n\n",
+        task_body.trim(),
+        parts.iteration
+    ));
+
+    out.push_str(
+        "Make focused progress toward completing only this single task. \
+         When the task is fully complete and no more work remains for it, \
+         output the literal token TASK_COMPLETE on its own line and stop. \
+         Do not start unrelated work even if you notice other issues — they belong to other tasks.\n",
+    );
+
+    out
+}
+
 pub fn save_prompt(prompts_dir: &Path, iteration: u32, body: &str) -> Result<()> {
     let path = prompts_dir.join(format!("iter-{iteration:04}.md"));
     fs::write(path, body)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -97,6 +97,25 @@ pub fn notes_path(project: &ProjectPaths) -> PathBuf {
     project.root.join("notes.md")
 }
 
+pub fn tasks_path(project: &ProjectPaths) -> PathBuf {
+    project.root.join("tasks.md")
+}
+
+pub fn seed_tasks_if_needed(project: &ProjectPaths, repo: &Path) -> Result<PathBuf> {
+    let dest = tasks_path(project);
+    if dest.exists() {
+        return Ok(dest);
+    }
+    let src = repo.join(".kobito/tasks.md");
+    let body = if src.exists() {
+        fs::read_to_string(&src)?
+    } else {
+        String::new()
+    };
+    fs::write(&dest, body)?;
+    Ok(dest)
+}
+
 pub fn list_projects() -> Result<()> {
     let root = state_root().join("projects");
     if !root.exists() {

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,117 @@
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::fs;
+use std::path::Path;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Task {
+    pub line_no: usize,
+    pub completed: bool,
+    pub body: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Backlog {
+    pub raw: String,
+    pub items: Vec<Task>,
+}
+
+impl Backlog {
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("read {}", path.display()))?;
+        Ok(Self::parse(&raw))
+    }
+
+    pub fn parse(raw: &str) -> Self {
+        let re = pattern();
+        let items = raw
+            .lines()
+            .enumerate()
+            .filter_map(|(line_no, line)| {
+                re.captures(line).map(|c| Task {
+                    line_no,
+                    completed: &c[1] != " ",
+                    body: c[2].to_string(),
+                })
+            })
+            .collect();
+        Self {
+            raw: raw.to_string(),
+            items,
+        }
+    }
+
+    pub fn pending(&self) -> Vec<&Task> {
+        self.items.iter().filter(|t| !t.completed).collect()
+    }
+
+    pub fn mark_completed(&mut self, line_no: usize) {
+        let trailing = self.raw.ends_with('\n');
+        let mut lines: Vec<String> = self.raw.lines().map(|s| s.to_string()).collect();
+        if let Some(line) = lines.get_mut(line_no) {
+            *line = pattern().replace(line, "- [x] $2").to_string();
+        }
+        let mut joined = lines.join("\n");
+        if trailing {
+            joined.push('\n');
+        }
+        self.raw = joined;
+        if let Some(item) = self.items.iter_mut().find(|t| t.line_no == line_no) {
+            item.completed = true;
+        }
+    }
+
+    pub fn write(&self, path: &Path) -> Result<()> {
+        fs::write(path, &self.raw)?;
+        Ok(())
+    }
+}
+
+fn pattern() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^- \[( |x|X)\] (.*)$").unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_extracts_checkboxes_and_skips_other_lines() {
+        let raw = "# Backlog\n\n- [ ] one\n- [x] two\nrandom line\n- [ ] three\n";
+        let b = Backlog::parse(raw);
+        assert_eq!(b.items.len(), 3);
+        assert_eq!(b.items[0].body, "one");
+        assert!(b.items[1].completed);
+        assert!(!b.items[2].completed);
+        assert_eq!(b.items[2].line_no, 5);
+    }
+
+    #[test]
+    fn mark_completed_rewrites_target_line_only() {
+        let mut b = Backlog::parse("- [ ] one\n- [ ] two\n- [ ] three\n");
+        b.mark_completed(1);
+        assert!(b.raw.contains("- [x] two"));
+        assert!(b.raw.contains("- [ ] one"));
+        assert!(b.raw.contains("- [ ] three"));
+        assert!(b.items[1].completed);
+        assert!(!b.items[0].completed);
+    }
+
+    #[test]
+    fn pending_excludes_completed() {
+        let b = Backlog::parse("- [x] done\n- [ ] todo\n");
+        let pending = b.pending();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].body, "todo");
+    }
+
+    #[test]
+    fn round_trip_preserves_trailing_newline() {
+        let mut b = Backlog::parse("- [ ] one\n");
+        b.mark_completed(0);
+        assert!(b.raw.ends_with('\n'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of the kobito MVP roadmap: backlog-driven iteration mode (#3).

For each unchecked item in `tasks.md`:

1. Branch off the starting branch as `kobito/task-<n>-<slug>`.
2. Loop the agent on a per-task prompt until it emits `TASK_COMPLETE` (or the per-task iteration cap is hit).
3. Stage + commit each diff with an LLM-generated Conventional Commits message (reuses Phase 1 #4).
4. `git push` + `gh pr create` against the starting branch on success, then mark `[x]` in the state copy of `tasks.md`.
5. Always check out back to the starting branch — failure or skip never strands the user on a feature branch.

The state copy of `tasks.md` is the source of truth — `.kobito/tasks.md` is only ever read as the initial seed. `kobito tasks edit` opens the state copy in `\$EDITOR`.

## Commits

6 commits, each touching one concern:

| # | commit |
|---|--------|
| 1 | feat(tasks): parse and update Markdown checkbox backlog |
| 2 | feat(state): seed tasks.md from .kobito on first run (#3) |
| 3 | feat(cli): tasks edit opens state copy in \$EDITOR (#3) |
| 4 | feat(prompt): per-task iteration prompt with TASK_COMPLETE sentinel (#3) |
| 5 | feat(iteration): per-task branching with PR creation (#3) |
| 6 | docs: document iteration mode usage and gh dependency (#3) |

The parser in commit #1 ships with 4 unit tests (parse / pending / mark / round-trip).

## New runtime dependency

Iteration mode additionally requires the [`gh`](https://cli.github.com/) CLI to be installed and authenticated for the project's remote. Documented in the README.

## Test plan

- [ ] `cargo test` — tasks parser unit tests pass
- [ ] `cargo build --release`
- [ ] `kobito --help` shows the new `iteration` subcommand
- [ ] `kobito tasks edit` opens \$EDITOR on the state copy
- [ ] `kobito iteration` on a sample repo with a 3-task `tasks.md` produces 3 PRs and leaves all items `[x]` in the state copy
- [ ] Failed task (e.g. agent error past --max-failures) is skipped and does not block subsequent tasks
- [ ] Ctrl-C between tasks returns to the starting branch cleanly

Closes #3.