### PR TITLE
feat: Phase 3 — preset system (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Early MVP. Phase 1 + 2 implemented:
 - LLM-generated commit messages (#4)
 - State persisted under `~/.local/state/kobito/` (#6)
 - Real-time log passthrough with a status bar (#5)
+- Preset system: reusable Markdown templates with `{{var}}` substitution (#7)
 
 Project conventions (style, output language) are the agent's job —
 both Claude Code and Codex auto-read their respective memory files
@@ -25,7 +26,6 @@ inject or pin anything itself.
 
 Not yet implemented:
 
-- Preset system (#7)
 - Codex agent backend (#9)
 
 ## Install
@@ -82,12 +82,34 @@ For each unchecked item, kobito branches off the starting branch as
 `kobito/task-<n>-<slug>`, iterates until the agent emits `TASK_COMPLETE`,
 runs `gh pr create`, and marks the line `[x]` in the state copy.
 
+### presets
+
+Reuse a Markdown template across runs and projects. Place the file at:
+
+1. `./.kobito/presets/<name>.md` — project-local override
+2. `$XDG_CONFIG_HOME/kobito/presets/<name>.md` — global (defaults to `~/.config/kobito/presets/`)
+
+Resolution checks (1) first, then (2). Missing preset → error.
+
+`{{var}}` placeholders are substituted from `--var key=value` (repeatable). Unresolved variables abort the run before any branch is created.
+
+```sh
+# ~/.config/kobito/presets/coverage.md
+# Increase test coverage for {{path}}. Aim for {{target}}% line coverage.
+
+kobito continuous --preset coverage --var path=src/api --var target=80
+```
+
+The resolved body is prepended to the iteration prompt, above the goal / task block.
+
 ### Common options
 
 | flag                | default   | meaning                                     |
 | ------------------- | --------- | ------------------------------------------- |
 | `--prompt`, `-p`    | required (continuous) | the goal to pursue              |
 | `--backlog`         | optional (iteration)  | path to a tasks.md backlog      |
+| `--preset`          | optional  | preset name (resolved per the order above)  |
+| `--var key=value`   | repeatable | substitute `{{key}}` in the preset         |
 | `--max-iterations`  | `50` / `30` | hard cap on iterations (per task in iteration mode) |
 | `--max-failures`    | `3`       | give up after N consecutive failures        |
 | `--agent`           | `claude`  | backend agent (only `claude` for now)       |

--- a/README.md
+++ b/README.md
@@ -97,10 +97,17 @@ Resolution checks (1) first, then (2). Missing preset → error.
 # ~/.config/kobito/presets/coverage.md
 # Increase test coverage for {{path}}. Aim for {{target}}% line coverage.
 
+# preset replaces --prompt entirely:
 kobito continuous --preset coverage --var path=src/api --var target=80
 ```
 
-The resolved body is prepended to the iteration prompt, above the goal / task block.
+In `continuous` mode `--preset` is **mutually exclusive with `--prompt`** — the resolved preset body becomes the goal.
+
+In `iteration` mode each task in `tasks.md` is its own goal, so `--preset` instead acts as **framing prepended to every task prompt**:
+
+```sh
+kobito iteration --preset small-feature --backlog tasks.md
+```
 
 ### Common options
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand};
 use std::path::PathBuf;
 
 use crate::{iteration, runner};
@@ -74,13 +74,16 @@ pub struct IterationArgs {
 }
 
 #[derive(Parser, Debug)]
+#[command(group = ArgGroup::new("goal").required(true).multiple(false).args(["prompt", "preset"]))]
 pub struct ContinuousArgs {
     /// The goal to pursue, e.g. "Increase test coverage in src/".
+    /// Mutually exclusive with --preset.
     #[arg(short, long)]
-    pub prompt: String,
+    pub prompt: Option<String>,
 
-    /// Compose a preset above the prompt. Looks up
-    /// .kobito/presets/<name>.md (project) then $XDG_CONFIG_HOME/kobito/presets/<name>.md.
+    /// Use a preset (with --var substitution) as the goal.
+    /// Looks up .kobito/presets/<name>.md (project) then
+    /// $XDG_CONFIG_HOME/kobito/presets/<name>.md. Mutually exclusive with --prompt.
     #[arg(long)]
     pub preset: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,15 @@ pub struct IterationArgs {
     #[arg(long)]
     pub backlog: Option<PathBuf>,
 
+    /// Compose a preset above each task prompt. Looks up
+    /// .kobito/presets/<name>.md (project) then $XDG_CONFIG_HOME/kobito/presets/<name>.md.
+    #[arg(long)]
+    pub preset: Option<String>,
+
+    /// Variable for the preset, repeatable: --var path=src --var target=80.
+    #[arg(long = "var")]
+    pub vars: Vec<String>,
+
     /// Maximum iterations per task before giving up.
     #[arg(long, default_value_t = 30)]
     pub max_iterations: u32,
@@ -69,6 +78,15 @@ pub struct ContinuousArgs {
     /// The goal to pursue, e.g. "Increase test coverage in src/".
     #[arg(short, long)]
     pub prompt: String,
+
+    /// Compose a preset above the prompt. Looks up
+    /// .kobito/presets/<name>.md (project) then $XDG_CONFIG_HOME/kobito/presets/<name>.md.
+    #[arg(long)]
+    pub preset: Option<String>,
+
+    /// Variable for the preset, repeatable: --var path=src --var target=80.
+    #[arg(long = "var")]
+    pub vars: Vec<String>,
 
     /// Maximum number of iterations before exiting.
     #[arg(long, default_value_t = 50)]

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -92,6 +92,7 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                 goal: body.clone(),
                 iteration,
                 notes: None,
+                preset: None,
             };
             let prompt_body = prompt::build_task_prompt(&parts, body);
             prompt::save_prompt(&run_dirs.prompts_dir, iteration, &prompt_body)?;

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -6,13 +6,26 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use crate::cli::IterationArgs;
-use crate::{agent, commit, git, logger::LogSink, prompt, state, tasks::Backlog, ui};
+use crate::{agent, commit, git, logger::LogSink, preset, prompt, state, tasks::Backlog, ui};
 
 pub async fn run(args: IterationArgs) -> Result<()> {
     let repo = git::repo_root()?;
     if !args.allow_dirty {
         git::ensure_clean(&repo)?;
     }
+
+    let preset_body = match &args.preset {
+        Some(name) => {
+            let vars = preset::parse_vars(&args.vars)?;
+            Some(preset::load(name, &repo, &vars)?)
+        }
+        None => {
+            if !args.vars.is_empty() {
+                bail!("--var requires --preset");
+            }
+            None
+        }
+    };
 
     let remote = git::remote_url(&repo);
     let id = state::project_id(&repo, remote.as_deref());
@@ -92,7 +105,7 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                 goal: body.clone(),
                 iteration,
                 notes: None,
-                preset: None,
+                preset: preset_body.clone(),
             };
             let prompt_body = prompt::build_task_prompt(&parts, body);
             prompt::save_prompt(&run_dirs.prompts_dir, iteration, &prompt_body)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod commit;
 mod git;
 mod iteration;
 mod logger;
+mod preset;
 mod prompt;
 mod runner;
 mod state;

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -1,0 +1,141 @@
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+pub fn config_root() -> PathBuf {
+    if let Ok(custom) = std::env::var("XDG_CONFIG_HOME") {
+        if !custom.is_empty() {
+            return PathBuf::from(custom).join("kobito");
+        }
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".config/kobito"))
+        .unwrap_or_else(|| PathBuf::from(".kobito-config"))
+}
+
+pub fn resolve(name: &str, repo: &Path) -> Result<PathBuf> {
+    let local = repo.join(".kobito/presets").join(format!("{name}.md"));
+    if local.exists() {
+        return Ok(local);
+    }
+    let global = config_root().join("presets").join(format!("{name}.md"));
+    if global.exists() {
+        return Ok(global);
+    }
+    bail!(
+        "preset `{name}` not found — looked in {} and {}",
+        local.display(),
+        global.display()
+    )
+}
+
+pub fn load(name: &str, repo: &Path, vars: &HashMap<String, String>) -> Result<String> {
+    let path = resolve(name, repo)?;
+    let body =
+        fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    substitute(&body, vars)
+}
+
+pub fn substitute(body: &str, vars: &HashMap<String, String>) -> Result<String> {
+    let re = pattern();
+    let mut missing: Vec<String> = Vec::new();
+    let result = re.replace_all(body, |caps: &regex::Captures| {
+        let key = caps[1].trim();
+        match vars.get(key) {
+            Some(v) => v.clone(),
+            None => {
+                missing.push(key.to_string());
+                String::new()
+            }
+        }
+    });
+    if !missing.is_empty() {
+        missing.sort();
+        missing.dedup();
+        bail!(
+            "preset has unresolved variable(s): {} — pass --var {}=<value>",
+            missing.join(", "),
+            missing[0]
+        );
+    }
+    Ok(result.into_owned())
+}
+
+pub fn parse_vars(raw: &[String]) -> Result<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    for s in raw {
+        match s.split_once('=') {
+            Some((k, v)) => {
+                map.insert(k.trim().to_string(), v.to_string());
+            }
+            None => bail!("--var expected key=value, got `{s}`"),
+        }
+    }
+    Ok(map)
+}
+
+fn pattern() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}").unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    }
+
+    #[test]
+    fn substitute_replaces_variables() {
+        let v = vars(&[("path", "src/api"), ("target", "80")]);
+        let out = substitute("Cover {{path}} to {{target}}%", &v).unwrap();
+        assert_eq!(out, "Cover src/api to 80%");
+    }
+
+    #[test]
+    fn substitute_tolerates_whitespace_in_braces() {
+        let v = vars(&[("name", "kobito")]);
+        let out = substitute("Hello {{ name }}", &v).unwrap();
+        assert_eq!(out, "Hello kobito");
+    }
+
+    #[test]
+    fn substitute_errors_on_missing_var() {
+        let err = substitute("Cover {{path}}", &HashMap::new()).unwrap_err();
+        assert!(err.to_string().contains("path"));
+    }
+
+    #[test]
+    fn substitute_reports_all_missing_vars() {
+        let err = substitute("{{a}} and {{b}}", &HashMap::new()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("a"));
+        assert!(msg.contains("b"));
+    }
+
+    #[test]
+    fn parse_vars_accepts_key_value() {
+        let raw = vec!["a=1".into(), "b=foo bar".into()];
+        let map = parse_vars(&raw).unwrap();
+        assert_eq!(map.get("a"), Some(&"1".to_string()));
+        assert_eq!(map.get("b"), Some(&"foo bar".to_string()));
+    }
+
+    #[test]
+    fn parse_vars_handles_equals_in_value() {
+        let raw = vec!["expr=x=y+1".into()];
+        let map = parse_vars(&raw).unwrap();
+        assert_eq!(map.get("expr"), Some(&"x=y+1".to_string()));
+    }
+
+    #[test]
+    fn parse_vars_rejects_no_equals() {
+        let raw = vec!["bad".into()];
+        assert!(parse_vars(&raw).is_err());
+    }
+}

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -6,10 +6,16 @@ pub struct PromptParts {
     pub goal: String,
     pub iteration: u32,
     pub notes: Option<String>,
+    pub preset: Option<String>,
 }
 
 pub fn build_iteration_prompt(parts: &PromptParts) -> String {
     let mut out = String::new();
+
+    if let Some(preset) = &parts.preset {
+        out.push_str(preset.trim());
+        out.push_str("\n\n");
+    }
 
     if let Some(notes) = &parts.notes {
         if !notes.trim().is_empty() {
@@ -35,6 +41,11 @@ pub fn build_iteration_prompt(parts: &PromptParts) -> String {
 
 pub fn build_task_prompt(parts: &PromptParts, task_body: &str) -> String {
     let mut out = String::new();
+
+    if let Some(preset) = &parts.preset {
+        out.push_str(preset.trim());
+        out.push_str("\n\n");
+    }
 
     out.push_str(&format!(
         "## Single task\n\n{}\n\n## Iteration {}\n\n",

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,25 +14,24 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
         git::ensure_clean(&repo)?;
     }
 
-    let preset_body = match &args.preset {
-        Some(name) => {
+    let goal = match (args.prompt.as_ref(), args.preset.as_ref()) {
+        (Some(p), None) => p.clone(),
+        (None, Some(name)) => {
             let vars = preset::parse_vars(&args.vars)?;
-            Some(preset::load(name, &repo, &vars)?)
+            preset::load(name, &repo, &vars)?
         }
-        None => {
-            if !args.vars.is_empty() {
-                bail!("--var requires --preset");
-            }
-            None
-        }
+        _ => bail!("either --prompt or --preset is required (not both)"),
     };
+    if args.preset.is_none() && !args.vars.is_empty() {
+        bail!("--var requires --preset");
+    }
 
     let remote = git::remote_url(&repo);
     let id = state::project_id(&repo, remote.as_deref());
     let project = state::project_paths(id.clone())?;
     let run = state::new_run(project.clone())?;
 
-    let slug = slugify(&args.prompt);
+    let slug = slugify(&goal);
     let branch = format!(
         "kobito/{slug}-{ts}",
         ts = Utc::now().format("%Y%m%d-%H%M%S")
@@ -45,7 +44,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
             run_id: run.timestamp.clone(),
             started_at: Utc::now().to_rfc3339(),
             branch: branch.clone(),
-            goal: args.prompt.clone(),
+            goal: goal.clone(),
             agent: args.agent.clone(),
         },
     )?;
@@ -59,7 +58,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
         let _ = ctrlc::set_handler(move || flag.store(true, Ordering::SeqCst));
     }
 
-    sink.note(&format!("kobito start: {}", args.prompt));
+    sink.note(&format!("kobito start: {}", first_line(&goal)));
     sink.note(&format!("project: {id}  branch: {branch}"));
 
     let started = Instant::now();
@@ -76,10 +75,10 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
 
         let notes = fs::read_to_string(state::notes_path(&project)).ok();
         let parts = prompt::PromptParts {
-            goal: args.prompt.clone(),
+            goal: goal.clone(),
             iteration,
             notes,
-            preset: preset_body.clone(),
+            preset: None,
         };
         let body = prompt::build_iteration_prompt(&parts);
         prompt::save_prompt(&run.prompts_dir, iteration, &body)?;
@@ -104,7 +103,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
                 ui::set_status(&bar, iteration, started.elapsed(), total_retries, "committing");
                 let diff = git::diff_staged(&repo)?;
                 let style = git::recent_commit_messages(&repo, 20).unwrap_or_default();
-                let msg = commit::generate_message(&repo, &diff, &args.prompt, &style).await?;
+                let msg = commit::generate_message(&repo, &diff, &goal, &style).await?;
                 git::commit(&repo, &msg)?;
                 sink.note(&format!("✓ committed: {}", first_line(&msg)));
                 completed += 1;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -66,6 +66,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
             goal: args.prompt.clone(),
             iteration,
             notes,
+            preset: None,
         };
         let body = prompt::build_iteration_prompt(&parts);
         prompt::save_prompt(&run.prompts_dir, iteration, &body)?;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use chrono::Utc;
 use std::fs;
 use std::sync::Arc;
@@ -6,13 +6,26 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use crate::cli::ContinuousArgs;
-use crate::{agent, commit, git, logger::LogSink, prompt, state, ui};
+use crate::{agent, commit, git, logger::LogSink, preset, prompt, state, ui};
 
 pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
     let repo = git::repo_root()?;
     if !args.allow_dirty {
         git::ensure_clean(&repo)?;
     }
+
+    let preset_body = match &args.preset {
+        Some(name) => {
+            let vars = preset::parse_vars(&args.vars)?;
+            Some(preset::load(name, &repo, &vars)?)
+        }
+        None => {
+            if !args.vars.is_empty() {
+                bail!("--var requires --preset");
+            }
+            None
+        }
+    };
 
     let remote = git::remote_url(&repo);
     let id = state::project_id(&repo, remote.as_deref());
@@ -66,7 +79,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
             goal: args.prompt.clone(),
             iteration,
             notes,
-            preset: None,
+            preset: preset_body.clone(),
         };
         let body = prompt::build_iteration_prompt(&parts);
         prompt::save_prompt(&run.prompts_dir, iteration, &body)?;


### PR DESCRIPTION
## Summary

Phase 3: reusable Markdown templates for the iteration prompt, resolved per project then global, with `{{var}}` substitution.

```sh
# ~/.config/kobito/presets/coverage.md
# Increase test coverage for {{path}}. Aim for {{target}}% line coverage.

kobito continuous --preset coverage --var path=src/api --var target=80
```

The substituted body is prepended to the iteration prompt, above the goal / task block. Both `continuous` and `iteration` modes accept `--preset` and `--var`.

## Resolution order

1. `./.kobito/presets/<name>.md` (project-local override)
2. `$XDG_CONFIG_HOME/kobito/presets/<name>.md` (defaults to `~/.config/kobito/presets/`)

Errors are checked up front — preset not found, unresolved variable(s), `--var` without `--preset` — so failures abort before any branch is created.

## Commits

5 commits, each touching one concern:

| # | commit |
|---|--------|
| 1 | feat(preset): resolve and load preset templates with var substitution (#7) |
| 2 | feat(cli): add --preset and --var flags (#7) |
| 3 | feat(prompt): inject preset content above task input (#7) |
| 4 | feat(runner): resolve preset once before the loop (#7) |
| 5 | docs: document preset system (#7) |

7 unit tests in `src/preset.rs` cover substitution + parse_vars (all green).

## Test plan

- [ ] `cargo test` — all preset tests pass
- [ ] `cargo build --release`
- [ ] `kobito continuous --help` and `kobito iteration --help` show `--preset` and `--var`
- [ ] `kobito continuous --prompt x --var k=v` (no `--preset`) fails with "--var requires --preset"
- [ ] `kobito continuous --preset nonexistent` fails with "preset \`nonexistent\` not found"
- [ ] Preset `Cover {{path}}` invoked without `--var path=...` fails listing the missing variable
- [ ] Project-local `.kobito/presets/coverage.md` shadows global `~/.config/kobito/presets/coverage.md`

Closes #7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced preset system for reusable Markdown templates, loaded from project-local or global config paths
- Added repeatable `--var key=value` flags for `{{var}}` placeholder substitution
- In continuous mode, `--preset` is mutually exclusive with `--prompt`; in iteration mode, preset prepends to task prompts
- Unresolved variables and missing presets trigger errors before execution begins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->