### PR TITLE
feat: per-run notes auto-maintenance and resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +451,7 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "dialoguer",
  "dirs",
  "indicatif",
  "regex",
@@ -724,6 +736,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
+dialoguer = { version = "0.11", default-features = false }
 dirs = "5"
 indicatif = "0.17"
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -154,12 +154,17 @@ outputs are skipped.
 ### Resuming
 
 ```sh
-# resume the most recent run on the current project
+# interactive picker — shows the 10 most recent runs
 kobito resume
 
 # or resume a specific run id (the timestamp dir name)
 kobito resume --run 2026-05-01T12-00-00
 ```
+
+`kobito resume` without `--run` opens an arrow-key picker listing the most
+recent runs (id, branch, first line of the goal). When there is only one
+prior run, or when stdin is not a TTY (CI, pipes), it auto-picks the
+latest.
 
 Resume re-uses the original branch and agent from the run's
 `meta.json`, opens a new run directory, and copies the previous

--- a/README.md
+++ b/README.md
@@ -129,23 +129,42 @@ kobito iteration --preset small-feature --backlog tasks.md
 ~/.local/state/kobito/
 └── projects/
     └── <repo-basename>-<sha1[:8]>/
-        ├── notes.md            # cross-iteration learnings, auto-maintained by the agent
-        ├── current-run.json    # active run metadata
+        ├── tasks.md                # iteration backlog (state copy)
         └── runs/
-            └── 2026-05-01T12-00-00/
-                ├── log.ndjson  # streamed agent output
+            └── 2026-05-01T12-00-00/   # one directory per invocation = run id
+                ├── meta.json       # branch, goal, agent — used for resume
+                ├── notes.md        # cross-iteration learnings, agent-maintained
+                ├── log.ndjson      # streamed agent output
                 └── prompts/
                     └── iter-0001.md
 ```
 
+`notes.md` lives **per run**, not per project. Each invocation gets a
+fresh memory file, and iteration mode (which starts a new run per
+task) automatically gets a separate notes.md per task — coverage
+push and refactor learnings don't bleed into each other.
+
 After every commit, the agent is asked in a one-shot call to write
 1-5 short bullets distilling what is useful for the next iteration —
 surprising findings, dead-ends, paths or commands worth remembering —
-and the result is appended to `notes.md` under a timestamped header.
-At the start of every iteration, `notes.md` is read back into the
-prompt as cross-iteration memory, so retries and follow-ups see
-what the previous iterations learned. Empty / `NO_NOTES` outputs are
-skipped so quiet iterations don't dilute the file.
+appended under a timestamped header. The next iteration reads the
+file back into the prompt as cross-iteration memory. Empty / `NO_NOTES`
+outputs are skipped.
+
+### Resuming
+
+```sh
+# resume the most recent run on the current project
+kobito resume
+
+# or resume a specific run id (the timestamp dir name)
+kobito resume --run 2026-05-01T12-00-00
+```
+
+Resume re-uses the original branch and agent from the run's
+`meta.json`, opens a new run directory, and copies the previous
+`notes.md` as the starting memory so the loop picks up with what
+the earlier iterations learned.
 
 `$XDG_STATE_HOME` is honoured if set.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ kobito iteration --preset small-feature --backlog tasks.md
 ~/.local/state/kobito/
 └── projects/
     └── <repo-basename>-<sha1[:8]>/
-        ├── notes.md            # cross-iteration scratch memory (read-only to kobito today)
+        ├── notes.md            # cross-iteration learnings, auto-maintained by the agent
         ├── current-run.json    # active run metadata
         └── runs/
             └── 2026-05-01T12-00-00/
@@ -137,6 +137,15 @@ kobito iteration --preset small-feature --backlog tasks.md
                 └── prompts/
                     └── iter-0001.md
 ```
+
+After every commit, the agent is asked in a one-shot call to write
+1-5 short bullets distilling what is useful for the next iteration —
+surprising findings, dead-ends, paths or commands worth remembering —
+and the result is appended to `notes.md` under a timestamped header.
+At the start of every iteration, `notes.md` is read back into the
+prompt as cross-iteration memory, so retries and follow-ups see
+what the previous iterations learned. Empty / `NO_NOTES` outputs are
+skipped so quiet iterations don't dilute the file.
 
 `$XDG_STATE_HOME` is honoured if set.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ pub enum Command {
     Ls,
     /// Replay the last run's log for a project.
     Log { project: Option<String> },
-    /// Resume a previous continuous run (latest by default, or --run <id>).
+    /// Resume a previous continuous run (interactive picker, or --run <id>).
     Resume(ResumeArgs),
     /// Manage the iteration backlog.
     Tasks {
@@ -42,7 +42,9 @@ pub enum TasksAction {
 
 #[derive(Parser, Debug)]
 pub struct ResumeArgs {
-    /// Run id to resume (timestamp directory name). Defaults to the latest.
+    /// Run id to resume (timestamp directory name). If omitted, an
+    /// interactive picker shows the 10 most recent runs (auto-picks the
+    /// only one when there's just one, or in non-interactive shells).
     #[arg(long)]
     pub run: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,8 +25,8 @@ pub enum Command {
     Ls,
     /// Replay the last run's log for a project.
     Log { project: Option<String> },
-    /// Resume iteration mode from where it stopped.
-    Resume { project: Option<String> },
+    /// Resume a previous continuous run (latest by default, or --run <id>).
+    Resume(ResumeArgs),
     /// Manage the iteration backlog.
     Tasks {
         #[command(subcommand)]
@@ -38,6 +38,25 @@ pub enum Command {
 pub enum TasksAction {
     /// Open $EDITOR on the state copy of tasks.md.
     Edit,
+}
+
+#[derive(Parser, Debug)]
+pub struct ResumeArgs {
+    /// Run id to resume (timestamp directory name). Defaults to the latest.
+    #[arg(long)]
+    pub run: Option<String>,
+
+    /// Maximum iterations before exiting.
+    #[arg(long, default_value_t = 50)]
+    pub max_iterations: u32,
+
+    /// Maximum consecutive failures before giving up.
+    #[arg(long, default_value_t = 3)]
+    pub max_failures: u32,
+
+    /// Skip the clean-tree check (dangerous).
+    #[arg(long)]
+    pub allow_dirty: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -112,13 +131,12 @@ pub async fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
         Command::Continuous(args) => runner::run_continuous(args).await,
         Command::Iteration(args) => iteration::run(args).await,
+        Command::Resume(args) => runner::resume_continuous(args).await,
         Command::Ls => crate::state::list_projects(),
         Command::Tasks {
             action: TasksAction::Edit,
         } => edit_tasks(),
-        Command::Log { .. } | Command::Resume { .. } => {
-            bail!("not yet implemented — tracked in #6")
-        }
+        Command::Log { .. } => bail!("not yet implemented"),
     }
 }
 

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use crate::cli::IterationArgs;
 use crate::{
-    agent, branch, commit, git, logger::LogSink, preset, prompt, state, tasks::Backlog, ui,
+    agent, branch, commit, git, logger::LogSink, notes, preset, prompt, state, tasks::Backlog, ui,
 };
 
 pub async fn run(args: IterationArgs) -> Result<()> {
@@ -133,6 +133,20 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                             "✓ committed: {}",
                             msg.lines().next().unwrap_or("")
                         ));
+
+                        let notes_path = state::notes_path(&project);
+                        if let Err(e) = notes::append_learning(
+                            &*agent_impl,
+                            &repo,
+                            &notes_path,
+                            iteration,
+                            body,
+                            &diff,
+                        )
+                        .await
+                        {
+                            sink.note(&format!("notes update failed: {e}"));
+                        }
                     } else {
                         sink.note("no diff this iteration");
                     }

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -134,7 +134,7 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                             msg.lines().next().unwrap_or("")
                         ));
 
-                        let notes_path = state::notes_path(&project);
+                        let notes_path = state::notes_path(&run_dirs);
                         if let Err(e) = notes::append_learning(
                             &*agent_impl,
                             &repo,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod commit;
 mod git;
 mod iteration;
 mod logger;
+mod notes;
 mod preset;
 mod prompt;
 mod runner;

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -1,0 +1,99 @@
+use anyhow::Result;
+use chrono::Utc;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use crate::agent::{self, Agent};
+
+const NO_NOTES: &str = "NO_NOTES";
+
+pub async fn append_learning(
+    agent: &dyn Agent,
+    repo: &Path,
+    notes_path: &Path,
+    iteration: u32,
+    iteration_goal: &str,
+    diff: &str,
+) -> Result<bool> {
+    let prompt = format!(
+        "You just finished one iteration of an autonomous task. Distill what is \
+         useful to remember for the next iteration: surprising findings, \
+         constraints discovered, dead-ends to avoid, file paths or commands worth \
+         keeping. Skip the obvious — only what would change a future attempt.\n\n\
+         Output 1 to 5 short bullets, plain text, no preamble, no explanation, \
+         no markdown fences. If nothing non-obvious was learned, output the \
+         literal token {NO_NOTES} and nothing else.\n\n\
+         ## Iteration goal\n\n{iteration_goal}\n\n\
+         ## What happened (diff)\n\n```diff\n{diff_excerpt}\n```\n",
+        diff_excerpt = excerpt(diff, 4_000),
+    );
+
+    let raw = agent::run_oneshot(agent, repo, &prompt).await?;
+    let cleaned = clean(&raw);
+    if cleaned.is_empty() || cleaned == NO_NOTES {
+        return Ok(false);
+    }
+
+    append_section(notes_path, iteration, &cleaned)?;
+    Ok(true)
+}
+
+fn excerpt(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let head = &s[..max / 2];
+    let tail = &s[s.len() - max / 2..];
+    format!("{head}\n…\n[diff truncated]\n…\n{tail}")
+}
+
+fn clean(raw: &str) -> String {
+    let mut s = raw.trim().to_string();
+    if s.starts_with("```") {
+        let after = s.splitn(2, '\n').nth(1).unwrap_or("").to_string();
+        s = after.trim_end_matches("```").trim().to_string();
+    }
+    s
+}
+
+fn append_section(path: &Path, iteration: u32, body: &str) -> Result<()> {
+    let header = format!(
+        "\n## iteration {iteration} — {ts}\n\n",
+        ts = Utc::now().to_rfc3339()
+    );
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(header.as_bytes())?;
+    file.write_all(body.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_strips_fences() {
+        assert_eq!(clean("```\n- one\n- two\n```"), "- one\n- two");
+        assert_eq!(clean("```text\n- a\n```"), "- a");
+    }
+
+    #[test]
+    fn clean_preserves_plain() {
+        assert_eq!(clean("- one\n- two\n"), "- one\n- two");
+    }
+
+    #[test]
+    fn excerpt_passes_through_when_short() {
+        assert_eq!(excerpt("short", 100), "short");
+    }
+
+    #[test]
+    fn excerpt_truncates_when_long() {
+        let s: String = "x".repeat(10_000);
+        let out = excerpt(&s, 4_000);
+        assert!(out.contains("[diff truncated]"));
+        assert!(out.len() < 5_000);
+    }
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,11 +1,14 @@
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 use chrono::Utc;
+use indicatif::ProgressBar;
 use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
-use crate::cli::ContinuousArgs;
+use crate::agent::Agent;
+use crate::cli::{ContinuousArgs, ResumeArgs};
 use crate::{agent, branch, commit, git, logger::LogSink, notes, preset, prompt, state, ui};
 
 pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
@@ -55,91 +58,27 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
 
     let bar = ui::make_status_bar();
     let sink = LogSink::open(&run.log_file, Some(bar.clone()))?;
-
-    let cancelled = Arc::new(AtomicBool::new(false));
-    {
-        let flag = cancelled.clone();
-        let _ = ctrlc::set_handler(move || flag.store(true, Ordering::SeqCst));
-    }
+    let cancelled = install_cancel_handler();
 
     sink.note(&format!("kobito start: {}", first_line(&goal)));
-    sink.note(&format!("project: {id}  branch: {branch}"));
+    sink.note(&format!(
+        "project: {id}  branch: {branch}  run: {}",
+        run.timestamp
+    ));
 
-    let started = Instant::now();
-    let mut consecutive_failures = 0u32;
-    let mut total_retries = 0u32;
-    let mut completed = 0u32;
-
-    for iteration in 1..=args.max_iterations {
-        if cancelled.load(Ordering::SeqCst) {
-            sink.note("interrupted by user");
-            break;
-        }
-        ui::set_status(&bar, iteration, started.elapsed(), total_retries, "thinking");
-
-        let notes = fs::read_to_string(state::notes_path(&run)).ok();
-        let parts = prompt::PromptParts {
-            goal: goal.clone(),
-            iteration,
-            notes,
-            preset: None,
-        };
-        let body = prompt::build_iteration_prompt(&parts);
-        prompt::save_prompt(&run.prompts_dir, iteration, &body)?;
-
-        let outcome = agent::run(&*agent_impl, &repo, &body, &sink).await;
-
-        match outcome {
-            Ok(out) => {
-                consecutive_failures = 0;
-                if out.natural_stop {
-                    sink.note("agent reported NATURAL_STOP — exiting cleanly");
-                    break;
-                }
-                git::stage_all(&repo)?;
-                if !git::has_staged_changes(&repo)? {
-                    sink.note("iteration produced no diff — skipping commit");
-                    continue;
-                }
-                ui::set_status(&bar, iteration, started.elapsed(), total_retries, "committing");
-                let diff = git::diff_staged(&repo)?;
-                let style = git::recent_commit_messages(&repo, 20).unwrap_or_default();
-                let msg =
-                    commit::generate_message(&*agent_impl, &repo, &diff, &goal, &style).await?;
-                git::commit(&repo, &msg)?;
-                sink.note(&format!("✓ committed: {}", first_line(&msg)));
-                completed += 1;
-
-                let notes_path = state::notes_path(&run);
-                if let Err(e) = notes::append_learning(
-                    &*agent_impl,
-                    &repo,
-                    &notes_path,
-                    iteration,
-                    &goal,
-                    &diff,
-                )
-                .await
-                {
-                    sink.note(&format!("notes update failed: {e}"));
-                }
-            }
-            Err(e) => {
-                consecutive_failures += 1;
-                total_retries += 1;
-                sink.note(&format!("✗ iteration failed: {e}"));
-                git::reset_hard(&repo).ok();
-                if consecutive_failures >= args.max_failures {
-                    sink.note(&format!(
-                        "giving up after {consecutive_failures} consecutive failures"
-                    ));
-                    break;
-                }
-                let backoff = std::time::Duration::from_secs(2u64.pow(consecutive_failures));
-                tokio::time::sleep(backoff).await;
-            }
-        }
-    }
+    let completed = run_iterations(LoopArgs {
+        agent: &*agent_impl,
+        repo: &repo,
+        run: &run,
+        branch: &branch,
+        goal: &goal,
+        max_iterations: args.max_iterations,
+        max_failures: args.max_failures,
+        sink: &sink,
+        bar: &bar,
+        cancelled,
+    })
+    .await?;
 
     bar.finish_and_clear();
     sink.note(&format!(
@@ -147,6 +86,187 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
         run.run_dir.display()
     ));
     Ok(())
+}
+
+pub async fn resume_continuous(args: ResumeArgs) -> Result<()> {
+    let repo = git::repo_root()?;
+    if !args.allow_dirty {
+        git::ensure_clean(&repo)?;
+    }
+
+    let remote = git::remote_url(&repo);
+    let id = state::project_id(&repo, remote.as_deref());
+    let project = state::project_paths(id.clone())?;
+
+    let target_id = match args.run.as_ref() {
+        Some(s) => s.clone(),
+        None => state::latest_run_id(&project)?
+            .ok_or_else(|| anyhow!("no previous runs to resume in {}", project.root.display()))?,
+    };
+    let (prev_meta, prev_run) = state::read_run_meta(&project, &target_id)?;
+    let agent_impl = agent::from_name(&prev_meta.agent)?;
+
+    git::checkout(&repo, &prev_meta.branch)?;
+
+    let new_run = state::new_run(project.clone())?;
+    let prev_notes = state::notes_path(&prev_run);
+    if prev_notes.exists() {
+        fs::copy(&prev_notes, state::notes_path(&new_run))?;
+    }
+    state::write_run_meta(
+        &new_run,
+        &state::RunMeta {
+            run_id: new_run.timestamp.clone(),
+            started_at: Utc::now().to_rfc3339(),
+            branch: prev_meta.branch.clone(),
+            goal: prev_meta.goal.clone(),
+            agent: prev_meta.agent.clone(),
+        },
+    )?;
+
+    let bar = ui::make_status_bar();
+    let sink = LogSink::open(&new_run.log_file, Some(bar.clone()))?;
+    let cancelled = install_cancel_handler();
+
+    sink.note(&format!(
+        "kobito resume from {target_id}: {}",
+        first_line(&prev_meta.goal)
+    ));
+    sink.note(&format!(
+        "project: {id}  branch: {}  resumed run: {}",
+        prev_meta.branch, new_run.timestamp
+    ));
+
+    let completed = run_iterations(LoopArgs {
+        agent: &*agent_impl,
+        repo: &repo,
+        run: &new_run,
+        branch: &prev_meta.branch,
+        goal: &prev_meta.goal,
+        max_iterations: args.max_iterations,
+        max_failures: args.max_failures,
+        sink: &sink,
+        bar: &bar,
+        cancelled,
+    })
+    .await?;
+
+    bar.finish_and_clear();
+    sink.note(&format!(
+        "done — {completed} commits on {} (run dir: {})",
+        prev_meta.branch,
+        new_run.run_dir.display()
+    ));
+    Ok(())
+}
+
+struct LoopArgs<'a> {
+    agent: &'a dyn Agent,
+    repo: &'a Path,
+    run: &'a state::RunPaths,
+    branch: &'a str,
+    goal: &'a str,
+    max_iterations: u32,
+    max_failures: u32,
+    sink: &'a LogSink,
+    bar: &'a ProgressBar,
+    cancelled: Arc<AtomicBool>,
+}
+
+async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
+    let started = Instant::now();
+    let mut consecutive_failures = 0u32;
+    let mut total_retries = 0u32;
+    let mut completed = 0u32;
+
+    for iteration in 1..=args.max_iterations {
+        if args.cancelled.load(Ordering::SeqCst) {
+            args.sink.note("interrupted by user");
+            break;
+        }
+        ui::set_status(args.bar, iteration, started.elapsed(), total_retries, "thinking");
+
+        let notes = fs::read_to_string(state::notes_path(args.run)).ok();
+        let parts = prompt::PromptParts {
+            goal: args.goal.to_string(),
+            iteration,
+            notes,
+            preset: None,
+        };
+        let body = prompt::build_iteration_prompt(&parts);
+        prompt::save_prompt(&args.run.prompts_dir, iteration, &body)?;
+
+        match agent::run(args.agent, args.repo, &body, args.sink).await {
+            Ok(out) => {
+                consecutive_failures = 0;
+                if out.natural_stop {
+                    args.sink
+                        .note("agent reported NATURAL_STOP — exiting cleanly");
+                    break;
+                }
+                git::stage_all(args.repo)?;
+                if !git::has_staged_changes(args.repo)? {
+                    args.sink.note("iteration produced no diff — skipping commit");
+                    continue;
+                }
+                ui::set_status(
+                    args.bar,
+                    iteration,
+                    started.elapsed(),
+                    total_retries,
+                    "committing",
+                );
+                let diff = git::diff_staged(args.repo)?;
+                let style = git::recent_commit_messages(args.repo, 20).unwrap_or_default();
+                let msg =
+                    commit::generate_message(args.agent, args.repo, &diff, args.goal, &style)
+                        .await?;
+                git::commit(args.repo, &msg)?;
+                args.sink
+                    .note(&format!("✓ committed: {}", first_line(&msg)));
+                completed += 1;
+
+                let notes_path = state::notes_path(args.run);
+                if let Err(e) = notes::append_learning(
+                    args.agent,
+                    args.repo,
+                    &notes_path,
+                    iteration,
+                    args.goal,
+                    &diff,
+                )
+                .await
+                {
+                    args.sink.note(&format!("notes update failed: {e}"));
+                }
+            }
+            Err(e) => {
+                consecutive_failures += 1;
+                total_retries += 1;
+                args.sink.note(&format!("✗ iteration failed: {e}"));
+                git::reset_hard(args.repo).ok();
+                if consecutive_failures >= args.max_failures {
+                    args.sink.note(&format!(
+                        "giving up after {consecutive_failures} consecutive failures"
+                    ));
+                    break;
+                }
+                let backoff =
+                    std::time::Duration::from_secs(2u64.pow(consecutive_failures));
+                tokio::time::sleep(backoff).await;
+            }
+        }
+    }
+
+    let _ = args.branch;
+    Ok(completed)
+}
+
+fn install_cancel_handler() -> Arc<AtomicBool> {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let flag = cancelled.clone();
+    let _ = ctrlc::set_handler(move || flag.store(true, Ordering::SeqCst));
+    cancelled
 }
 
 fn slugify(s: &str) -> String {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -42,9 +42,9 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
     );
     git::create_and_checkout(&repo, &branch)?;
 
-    state::write_current_run(
-        &project,
-        &state::CurrentRun {
+    state::write_run_meta(
+        &run,
+        &state::RunMeta {
             run_id: run.timestamp.clone(),
             started_at: Utc::now().to_rfc3339(),
             branch: branch.clone(),
@@ -142,7 +142,6 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
     }
 
     bar.finish_and_clear();
-    state::clear_current_run(&project)?;
     sink.note(&format!(
         "done — {completed} commits on {branch} (run dir: {})",
         run.run_dir.display()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -77,7 +77,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
         }
         ui::set_status(&bar, iteration, started.elapsed(), total_retries, "thinking");
 
-        let notes = fs::read_to_string(state::notes_path(&project)).ok();
+        let notes = fs::read_to_string(state::notes_path(&run)).ok();
         let parts = prompt::PromptParts {
             goal: goal.clone(),
             iteration,
@@ -110,7 +110,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
                 sink.note(&format!("✓ committed: {}", first_line(&msg)));
                 completed += 1;
 
-                let notes_path = state::notes_path(&project);
+                let notes_path = state::notes_path(&run);
                 if let Err(e) = notes::append_learning(
                     &*agent_impl,
                     &repo,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, anyhow, bail};
 use chrono::Utc;
 use indicatif::ProgressBar;
 use std::fs;
+use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -100,8 +101,7 @@ pub async fn resume_continuous(args: ResumeArgs) -> Result<()> {
 
     let target_id = match args.run.as_ref() {
         Some(s) => s.clone(),
-        None => state::latest_run_id(&project)?
-            .ok_or_else(|| anyhow!("no previous runs to resume in {}", project.root.display()))?,
+        None => pick_run_to_resume(&project)?,
     };
     let (prev_meta, prev_run) = state::read_run_meta(&project, &target_id)?;
     let agent_impl = agent::from_name(&prev_meta.agent)?;
@@ -267,6 +267,32 @@ fn install_cancel_handler() -> Arc<AtomicBool> {
     let flag = cancelled.clone();
     let _ = ctrlc::set_handler(move || flag.store(true, Ordering::SeqCst));
     cancelled
+}
+
+fn pick_run_to_resume(project: &state::ProjectPaths) -> Result<String> {
+    let recent = state::recent_runs(project, 10)?;
+    if recent.is_empty() {
+        return Err(anyhow!(
+            "no previous runs to resume in {}",
+            project.root.display()
+        ));
+    }
+    if recent.len() == 1 || !std::io::stdin().is_terminal() {
+        return Ok(recent.into_iter().next().unwrap().id);
+    }
+    let labels: Vec<String> = recent
+        .iter()
+        .map(|r| {
+            let goal = first_line(&r.meta.goal).chars().take(60).collect::<String>();
+            format!("{}  [{}]  {goal}", r.id, r.meta.branch)
+        })
+        .collect();
+    let selection = dialoguer::Select::new()
+        .with_prompt("Resume which run?")
+        .items(&labels)
+        .default(0)
+        .interact()?;
+    Ok(recent[selection].id.clone())
 }
 
 fn slugify(s: &str) -> String {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use crate::cli::ContinuousArgs;
-use crate::{agent, branch, commit, git, logger::LogSink, preset, prompt, state, ui};
+use crate::{agent, branch, commit, git, logger::LogSink, notes, preset, prompt, state, ui};
 
 pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
     let agent_impl = agent::from_name(&args.agent)?;
@@ -109,6 +109,20 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
                 git::commit(&repo, &msg)?;
                 sink.note(&format!("✓ committed: {}", first_line(&msg)));
                 completed += 1;
+
+                let notes_path = state::notes_path(&project);
+                if let Err(e) = notes::append_learning(
+                    &*agent_impl,
+                    &repo,
+                    &notes_path,
+                    iteration,
+                    &goal,
+                    &diff,
+                )
+                .await
+                {
+                    sink.note(&format!("notes update failed: {e}"));
+                }
             }
             Err(e) => {
                 consecutive_failures += 1;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
@@ -22,8 +22,8 @@ pub struct RunPaths {
     pub timestamp: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CurrentRun {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunMeta {
     pub run_id: String,
     pub started_at: String,
     pub branch: String,
@@ -79,18 +79,43 @@ pub fn new_run(project: ProjectPaths) -> Result<RunPaths> {
     })
 }
 
-pub fn write_current_run(project: &ProjectPaths, run: &CurrentRun) -> Result<()> {
-    let path = project.root.join("current-run.json");
-    fs::write(path, serde_json::to_string_pretty(run)?)?;
+pub fn write_run_meta(run: &RunPaths, meta: &RunMeta) -> Result<()> {
+    let path = run.run_dir.join("meta.json");
+    fs::write(path, serde_json::to_string_pretty(meta)?)?;
     Ok(())
 }
 
-pub fn clear_current_run(project: &ProjectPaths) -> Result<()> {
-    let path = project.root.join("current-run.json");
-    if path.exists() {
-        fs::remove_file(path)?;
+pub fn read_run_meta(project: &ProjectPaths, run_id: &str) -> Result<(RunMeta, RunPaths)> {
+    let run_dir = project.root.join("runs").join(run_id);
+    if !run_dir.exists() {
+        bail!("run `{run_id}` not found in {}", project.root.display());
     }
-    Ok(())
+    let meta_path = run_dir.join("meta.json");
+    let body = fs::read_to_string(&meta_path)
+        .with_context(|| format!("read {}", meta_path.display()))?;
+    let meta: RunMeta = serde_json::from_str(&body)?;
+    let run = RunPaths {
+        project: project.clone(),
+        run_dir: run_dir.clone(),
+        log_file: run_dir.join("log.ndjson"),
+        prompts_dir: run_dir.join("prompts"),
+        timestamp: run_id.to_string(),
+    };
+    Ok((meta, run))
+}
+
+pub fn latest_run_id(project: &ProjectPaths) -> Result<Option<String>> {
+    let runs = project.root.join("runs");
+    if !runs.exists() {
+        return Ok(None);
+    }
+    let mut ids: Vec<String> = fs::read_dir(&runs)?
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    ids.sort();
+    Ok(ids.into_iter().last())
 }
 
 pub fn notes_path(run: &RunPaths) -> PathBuf {

--- a/src/state.rs
+++ b/src/state.rs
@@ -93,8 +93,8 @@ pub fn clear_current_run(project: &ProjectPaths) -> Result<()> {
     Ok(())
 }
 
-pub fn notes_path(project: &ProjectPaths) -> PathBuf {
-    project.root.join("notes.md")
+pub fn notes_path(run: &RunPaths) -> PathBuf {
+    run.run_dir.join("notes.md")
 }
 
 pub fn tasks_path(project: &ProjectPaths) -> PathBuf {

--- a/src/state.rs
+++ b/src/state.rs
@@ -104,18 +104,30 @@ pub fn read_run_meta(project: &ProjectPaths, run_id: &str) -> Result<(RunMeta, R
     Ok((meta, run))
 }
 
-pub fn latest_run_id(project: &ProjectPaths) -> Result<Option<String>> {
+#[derive(Debug, Clone)]
+pub struct RunSummary {
+    pub id: String,
+    pub meta: RunMeta,
+}
+
+pub fn recent_runs(project: &ProjectPaths, limit: usize) -> Result<Vec<RunSummary>> {
     let runs = project.root.join("runs");
     if !runs.exists() {
-        return Ok(None);
+        return Ok(vec![]);
     }
-    let mut ids: Vec<String> = fs::read_dir(&runs)?
+    let mut summaries: Vec<RunSummary> = fs::read_dir(&runs)?
         .flatten()
         .filter(|e| e.path().is_dir())
-        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter_map(|e| {
+            let id = e.file_name().to_string_lossy().to_string();
+            let body = fs::read_to_string(e.path().join("meta.json")).ok()?;
+            let meta: RunMeta = serde_json::from_str(&body).ok()?;
+            Some(RunSummary { id, meta })
+        })
         .collect();
-    ids.sort();
-    Ok(ids.into_iter().last())
+    summaries.sort_by(|a, b| b.id.cmp(&a.id));
+    summaries.truncate(limit);
+    Ok(summaries)
 }
 
 pub fn notes_path(run: &RunPaths) -> PathBuf {


### PR DESCRIPTION
## Summary

Three connected changes to cross-iteration memory:

### 1. Auto-maintain notes.md

After every commit, kobito asks the agent in a one-shot call for 1-5 bullets distilling what is useful for the next iteration — surprising findings, dead-ends, paths/commands worth remembering. The output is appended to `notes.md` under a timestamped header. The next iteration reads the file back as cross-iteration scratch memory. `NO_NOTES` (or empty) skips the append.

### 2. Per-run scoping

`notes.md` moves out of `projects/<id>/` and into `projects/<id>/runs/<ts>/notes.md`. Each invocation gets fresh memory; iteration mode (which calls `state::new_run` per task) automatically gets a separate notes.md per task, so coverage and refactor passes never share memory.

### 3. Resume command

```sh
kobito resume                          # latest run on this project
kobito resume --run 2026-05-01T12-00-00 # specific run id
```

Each run now writes `runs/<ts>/meta.json` (branch + goal + agent). Resume reads the previous meta, re-uses the same branch and agent, starts a new run directory, copies the previous `notes.md` in as starting memory, and enters the same continuous loop. Each resume is itself a fresh run id on disk, so a single goal can be picked up and dropped across many invocations.

The runner loop is extracted into `run_iterations(LoopArgs)` and shared between `run_continuous` and `resume_continuous` rather than duplicated.

## Commits

| # | commit |
|---|--------|
| 1 | feat(notes): generate per-iteration learnings via the agent |
| 2 | feat(runner): append iteration learnings to notes.md after each commit |
| 3 | docs: explain notes.md auto-maintenance |
| 4 | refactor(state): scope notes.md per run rather than per project |
| 5 | refactor(state): persist run meta inside the run dir for resume |
| 6 | feat(resume): kobito resume continues a previous continuous run |
| 7 | docs: document per-run notes scoping and the resume command |

`cargo test` — 18 tests (preset 7, tasks 4, branch 3, notes 4) all green.

## Test plan

- [ ] `cargo build --release`
- [ ] After 3 continuous iterations, `~/.local/state/kobito/projects/<id>/runs/<ts>/notes.md` shows three timestamped sections of learnings
- [ ] `kobito resume` reuses the previous branch, opens a new run dir with the prior notes copied in
- [ ] `kobito resume --run <id>` resumes that specific run
- [ ] `kobito resume` with no prior runs errors with "no previous runs to resume"
- [ ] Iteration mode produces a separate notes.md per task