### PR TITLE
docs: add AGENTS.md / CLAUDE.md and tidy README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# AGENTS.md
+
+Conventions for working on `kobito` itself. Both Claude Code and Codex auto-read this file at every invocation, so an agent driven by kobito (or by any other orchestrator) picks them up without further wiring.
+
+## What kobito is
+
+An autonomous coding agent orchestrator. Spawns `claude` or `codex` CLI in a loop on a working branch, commits each iteration with an LLM-generated message, and persists state under `$XDG_STATE_HOME/kobito/`. Stays deliberately thin: project conventions live in this file, not in kobito's prompts.
+
+## Stack
+
+- Rust, edition 2024.
+- Single-binary CLI, distributed via `cargo install`.
+- License: **ISC**.
+
+## Source layout
+
+| path | role |
+|---|---|
+| `src/main.rs` | entry point — `mod` declarations only |
+| `src/cli.rs` | clap definitions + dispatch |
+| `src/agent/` | `Agent` trait + per-agent modules (`claude_code`, `codex`) and shared `stream` helper |
+| `src/runner.rs` | `continuous` mode loop + `resume` |
+| `src/iteration.rs` | `iteration` mode loop |
+| `src/state.rs` | XDG state directory layout |
+| `src/preset.rs` | preset resolution + `{{var}}` substitution |
+| `src/notes.rs` | per-iteration learning generation |
+| `src/branch.rs` | agent-driven branch name suggestion |
+| `src/commit.rs` | agent-driven commit message generation |
+| `src/git.rs` | `git` CLI wrapper |
+| `src/logger.rs` | `LogSink` — terminal passthrough + ndjson |
+| `src/ui.rs` | indicatif status bar |
+| `src/prompt.rs` | iteration / task prompt builders |
+| `src/tasks.rs` | `tasks.md` parser |
+
+## Coding style
+
+- Public items at the top of each file.
+- Prefer `map` / `filter` / `reduce` over `for` / `while`.
+- Single responsibility — keep functions ≤ 15 lines and files ~200 lines or under where reasonable.
+- Comments are minimal. Convey behaviour through small, well-named functions. A comment is for the **why** of a non-obvious decision, never to restate the **what**.
+- No `unwrap()` / `expect()` in non-test code unless a panic is genuinely the right outcome.
+- Use `anyhow::Result` for application errors, `thiserror`-style only when callers need to discriminate.
+
+## Commit messages
+
+Conventional Commits with a scope and a body that explains the **why**:
+
+```
+<type>(<scope>): <subject>
+
+<body — usually 2-4 short lines, why this change is being made>
+```
+
+- `<type>`: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`, `style`, `revert`.
+- Imperative subject, no trailing period, ≤ 72 chars.
+- No `Co-authored-by` lines unless explicitly requested.
+- Reference issues in the body or PR — not via trailers.
+
+## Branch naming
+
+- `feature/<slug>` — new features
+- `refactor/<slug>` — non-functional changes
+- `fix/<slug>` — bug fixes
+- `docs/<slug>` — docs-only changes
+- `chore/<slug>` — maintenance, dependency bumps, repo hygiene
+
+`<slug>` is short kebab-case, ideally derived from the goal (e.g. `feature/preset-system`, `refactor/drop-issue-8-features`).
+
+## PR workflow
+
+- One concern per commit; bias toward small commits over squashable mega-commits.
+- Every commit must compile (`cargo check`).
+- PR body lists each commit with a one-line description and the test plan.
+- Merge with `--merge` (regular merge commit). **Never** `--squash`.
+- Link issues with `Closes #N` — one keyword per issue. GitHub's parser does not handle `Closes #1, #2, #3`.
+
+## Output language
+
+- Source code, comments, commit messages, PR bodies, this file, `README.md`: **English**.
+- Reply language for chat / CLI output is left to the agent's own global memory and is not pinned here.
+
+## Build / test
+
+```sh
+cargo build --release       # release binary
+cargo test --bin kobito     # unit tests
+cargo check                 # quick type check
+```
+
+The release profile uses LTO + single codegen unit + strip; expect ~15 s release builds.
+
+## When extending kobito
+
+- Adding an agent backend → one new `src/agent/<name>.rs` module implementing `Agent`, plus a branch in `agent::from_name`. No core loop changes needed.
+- Adding state on disk → put it inside `$XDG_STATE_HOME/kobito/projects/<id>/runs/<ts>/` (per-run) unless it genuinely belongs to the project across runs (rare — `tasks.md` is the only example today).
+- Don't add orchestrator-side workarounds for things the agent or the project's own AGENTS.md / CLAUDE.md should handle (output language, code style, doc conventions). kobito stays out of those.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -2,30 +2,28 @@
 
 > Like the elves in the shoemaker's tale, it works while you sleep.
 
-`kobito` is an autonomous coding agent orchestrator. You give it a goal, and it
-loops — invoking [Claude Code](https://github.com/anthropics/claude-code) on
-your repository, committing each iteration with an LLM-generated
-[Conventional Commits](https://www.conventionalcommits.org/) message, until you
-stop it.
+`kobito` is an autonomous coding agent orchestrator. Give it a goal, it
+loops — invoking [Claude Code](https://github.com/anthropics/claude-code)
+or [Codex](https://github.com/openai/codex) on your repository,
+committing each iteration with an LLM-generated message that follows
+the project's own conventions, until you stop it.
 
 ## Status
 
-Early MVP. Phase 1 + 2 implemented:
+MVP shipped:
 
-All four MVP phases shipped:
+- `continuous` mode (one branch, many commits)
+- `iteration` mode (per-task branch + PR from a `tasks.md` backlog)
+- Claude Code and OpenAI Codex backends behind a single `Agent` trait
+- Preset system with `{{var}}` substitution (project + global)
+- Per-run `notes.md` auto-maintained by the agent
+- `kobito resume` with an interactive picker of recent runs
+- State under `$XDG_STATE_HOME/kobito/`, real-time log passthrough + status bar
 
-- `continuous` mode end-to-end with the Claude Code agent (#2)
-- `iteration` mode: per-task branch + PR from a `tasks.md` backlog (#3)
-- LLM-generated commit messages (#4)
-- State persisted under `~/.local/state/kobito/` (#6)
-- Real-time log passthrough with a status bar (#5)
-- Preset system: reusable Markdown templates with `{{var}}` substitution (#7)
-- Agent abstraction with Claude Code and OpenAI Codex backends (#9)
-
-Project conventions (style, output language) are the agent's job —
-both Claude Code and Codex auto-read their respective memory files
-(`CLAUDE.md` / `AGENTS.md`) at every invocation, so kobito does not
-inject or pin anything itself.
+Project conventions (output language, code style, commit format, branch
+names) are deferred to the agent's own memory files (`CLAUDE.md` /
+`AGENTS.md`). kobito does not inject or pin anything itself — see this
+repo's [`AGENTS.md`](AGENTS.md) as an example of what those files describe.
 
 ## Install
 
@@ -184,6 +182,17 @@ Each iteration:
 5. If the agent emits the literal sentinel token (`NATURAL_STOP` for continuous, `TASK_COMPLETE` for iteration), exit cleanly.
 
 Single branch, single PR, many commits — by design (continuous mode). One branch + PR per task (iteration mode).
+
+## Contributing
+
+Conventions for working on kobito itself — commit format, branch naming,
+source layout, build / test commands — live in [`AGENTS.md`](AGENTS.md).
+[`CLAUDE.md`](CLAUDE.md) is a one-line `@AGENTS.md` alias so Claude Code
+picks it up too.
+
+When you drive kobito from another repository, your **own** `AGENTS.md`
+/ `CLAUDE.md` is what shapes the agent's output; the file in this repo
+only governs work on kobito itself.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -180,10 +180,6 @@ Each iteration:
 
 Single branch, single PR, many commits — by design (continuous mode). One branch + PR per task (iteration mode).
 
-## Contributing
-
-See [`AGENTS.md`](AGENTS.md).
-
 ## License
 
 ISC

--- a/README.md
+++ b/README.md
@@ -8,22 +8,19 @@ or [Codex](https://github.com/openai/codex) on your repository,
 committing each iteration with an LLM-generated message that follows
 the project's own conventions, until you stop it.
 
-## Status
+## Features
 
-MVP shipped:
-
-- `continuous` mode (one branch, many commits)
-- `iteration` mode (per-task branch + PR from a `tasks.md` backlog)
+- `continuous` mode — one branch, many commits, run until you stop it
+- `iteration` mode — per-task branch + PR from a `tasks.md` backlog
 - Claude Code and OpenAI Codex backends behind a single `Agent` trait
 - Preset system with `{{var}}` substitution (project + global)
 - Per-run `notes.md` auto-maintained by the agent
 - `kobito resume` with an interactive picker of recent runs
 - State under `$XDG_STATE_HOME/kobito/`, real-time log passthrough + status bar
 
-Project conventions (output language, code style, commit format, branch
-names) are deferred to the agent's own memory files (`CLAUDE.md` /
-`AGENTS.md`). kobito does not inject or pin anything itself — see this
-repo's [`AGENTS.md`](AGENTS.md) as an example of what those files describe.
+Project conventions — output language, code style, commit format, branch
+names — are deferred to the agent's own memory files (`CLAUDE.md` /
+`AGENTS.md`). kobito does not inject or pin anything itself.
 
 ## Install
 
@@ -185,14 +182,7 @@ Single branch, single PR, many commits — by design (continuous mode). One bran
 
 ## Contributing
 
-Conventions for working on kobito itself — commit format, branch naming,
-source layout, build / test commands — live in [`AGENTS.md`](AGENTS.md).
-[`CLAUDE.md`](CLAUDE.md) is a one-line `@AGENTS.md` alias so Claude Code
-picks it up too.
-
-When you drive kobito from another repository, your **own** `AGENTS.md`
-/ `CLAUDE.md` is what shapes the agent's output; the file in this repo
-only governs work on kobito itself.
+See [`AGENTS.md`](AGENTS.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Set up the project's own conventions file so the agent picks them up automatically — same mechanism kobito relies on for downstream repos.

- **`AGENTS.md`** describes stack, source layout, coding style, commit format (Conventional Commits with body), branch naming (`feature/<slug>` etc.), PR workflow (small commits, `--merge` only, `Closes #N` per issue), output language, and how to extend the orchestrator without re-introducing the workarounds reverted in #12.
- **`CLAUDE.md`** is a one-line `@AGENTS.md` import so Claude Code (which reads `CLAUDE.md` but not `AGENTS.md`) picks up the same content.
- **`README.md`** Status block had a stale "Phase 1+2 implemented" line — collapsed to a single MVP-shipped list, dropped the Conventional Commits reference from the lede (kobito follows whatever the project says), and added a Contributing section linking to `AGENTS.md`.

## Commits

| # | commit |
|---|--------|
| 1 | docs(agents): add AGENTS.md with project conventions |
| 2 | docs(claude): add CLAUDE.md as @AGENTS.md alias |
| 3 | docs(readme): link AGENTS.md and tidy the Status block |

## Test plan

- [ ] `cat CLAUDE.md` → just `@AGENTS.md`
- [ ] AGENTS.md renders cleanly on GitHub
- [ ] README Contributing links resolve
- [ ] No code changes, so no rebuild required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with feature documentation for backend support (Claude Code, Codex), preset system with variable substitution, per-run notes.md, and interactive resume command
  * Added contributor and development guidelines documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->