### PR TITLE
feat(prompt): meta instructions + iteration-mode notes leak fix

### DIFF
--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -111,10 +111,11 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                 consecutive_failures,
                 &format!("task {}/{}", task_idx, pending.len()),
             );
+            let notes = std::fs::read_to_string(state::notes_path(&run_dirs)).ok();
             let parts = prompt::PromptParts {
                 goal: body.clone(),
                 iteration,
-                notes: None,
+                notes,
                 preset: preset_body.clone(),
             };
             let prompt_body = prompt::build_task_prompt(&parts, body);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -9,8 +9,47 @@ pub struct PromptParts {
     pub preset: Option<String>,
 }
 
+const META_CONTINUOUS: &str = "\
+# About this run
+
+You are being driven by `kobito`, an autonomous orchestrator that spawns you in a loop. \
+Each invocation of you is one iteration:
+
+- The repo is checked out on a working branch dedicated to this run.
+- After this iteration finishes, the orchestrator stages any diff you produced and commits \
+  it with a generated message, then invokes a fresh you with the next iteration's prompt.
+- Use `git log` on the current branch to see what previous iterations of *this* run \
+  accomplished — your previous self has no in-process memory across iterations.
+- Any learnings you wrote in earlier iterations appear below under \"Cross-iteration notes\".
+- When the goal is fully reached or no meaningful work remains, output the literal token \
+  `NATURAL_STOP` on its own line and stop. The loop will exit cleanly. Otherwise make a \
+  small focused change and stop so it can be committed.
+
+";
+
+const META_ITERATION: &str = "\
+# About this run
+
+You are being driven by `kobito`, an autonomous orchestrator. This run focuses on **a single \
+task** picked from a backlog (`tasks.md`). Other tasks in the backlog are handled on \
+separate branches in separate runs — ignore them entirely, even if you notice issues that \
+could fix them.
+
+Each invocation of you is one iteration of this task's loop:
+
+- The repo is checked out on a working branch dedicated to this single task.
+- After this iteration finishes, the orchestrator stages any diff you produced and commits \
+  it with a generated message, then invokes a fresh you with the next iteration's prompt.
+- Use `git log` on the current branch to see what previous iterations of *this* task \
+  accomplished — your previous self has no in-process memory across iterations.
+- Any learnings you wrote in earlier iterations appear below under \"Cross-iteration notes\".
+- When the task is fully complete, output the literal token `TASK_COMPLETE` on its own \
+  line and stop. The loop will move on to the next task.
+
+";
+
 pub fn build_iteration_prompt(parts: &PromptParts) -> String {
-    let mut out = String::new();
+    let mut out = String::from(META_CONTINUOUS);
 
     if let Some(preset) = &parts.preset {
         out.push_str(preset.trim());
@@ -32,18 +71,25 @@ pub fn build_iteration_prompt(parts: &PromptParts) -> String {
     ));
 
     out.push_str(
-        "Make a small, self-contained improvement toward the goal. Stop when one logical change is complete so the diff can be committed. \
-        If the goal is already fully achieved or no meaningful work remains, reply with the literal token NATURAL_STOP and make no changes.\n",
+        "Make a small, self-contained improvement toward the goal. Stop when one logical change is complete so the diff can be committed.\n",
     );
 
     out
 }
 
 pub fn build_task_prompt(parts: &PromptParts, task_body: &str) -> String {
-    let mut out = String::new();
+    let mut out = String::from(META_ITERATION);
 
     if let Some(preset) = &parts.preset {
         out.push_str(preset.trim());
+        out.push_str("\n\n");
+    }
+
+    if let Some(notes) = &parts.notes
+        && !notes.trim().is_empty()
+    {
+        out.push_str("## Cross-iteration notes\n\n");
+        out.push_str(notes.trim());
         out.push_str("\n\n");
     }
 
@@ -54,10 +100,7 @@ pub fn build_task_prompt(parts: &PromptParts, task_body: &str) -> String {
     ));
 
     out.push_str(
-        "Make focused progress toward completing only this single task. \
-         When the task is fully complete and no more work remains for it, \
-         output the literal token TASK_COMPLETE on its own line and stop. \
-         Do not start unrelated work even if you notice other issues — they belong to other tasks.\n",
+        "Make focused progress toward completing only this single task. Stop when one logical change is complete so the diff can be committed.\n",
     );
 
     out


### PR DESCRIPTION
## Summary

The agent was being invoked once per iteration with no context about *what* an iteration is, why the repo is on a feature branch, what the sentinel tokens (`NATURAL_STOP` / `TASK_COMPLETE`) actually do, or how to recover what previous iterations did. \"Iteration 3\" alone is meaningless to a fresh process. Two fixes:

### 1. Meta instructions at the top of every prompt

Both `build_iteration_prompt` and `build_task_prompt` now prepend an \"About this run\" section that:

- Names kobito as the orchestrator and explains the loop
- Tells the agent to use `git log` to see what previous iterations of *this* run did
- Points at the Cross-iteration notes section
- Explains the sentinel as the way to break out of the loop, not just \"stop responding\"
- (iteration mode) Clarifies that other tasks in the backlog are handled on separate branches in separate runs and must be ignored

### 2. iteration-mode notes leak

`notes::append_learning` was already being called after every commit inside an iteration-mode task, but `build_task_prompt` was being passed `notes: None` so the file was never read back. Each iteration of a task therefore started fresh, ignoring what earlier iterations of the same task had learned. Now `state::notes_path(&run_dirs)` is read at the top of each iteration and threaded through, mirroring `run_continuous`.

## Commits

| # | commit |
|---|--------|
| 1 | feat(prompt): explain the iteration loop to the agent |
| 2 | fix(iteration): read per-task notes.md back into the prompt |

## Test plan

- [ ] `cargo test` — green
- [ ] Inspect `runs/<ts>/prompts/iter-0001.md` after a continuous run — has the About-this-run section, sentinel explanation, optional Cross-iteration notes, Goal
- [ ] Same for an iteration-mode run, with the \"other tasks are handled separately\" line
- [ ] After two iterations of one iteration-mode task, the second iteration's prompt contains the first iteration's learnings