### PR TITLE
feat(cli): rename continuous/iteration to cont/iter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ An autonomous coding agent orchestrator. Spawns `claude` or `codex` CLI in a loo
 | `src/main.rs` | entry point — `mod` declarations only |
 | `src/cli.rs` | clap definitions + dispatch |
 | `src/agent/` | `Agent` trait + per-agent modules (`claude_code`, `codex`) and shared `stream` helper |
-| `src/runner.rs` | `continuous` mode loop + `resume` |
-| `src/iteration.rs` | `iteration` mode loop |
+| `src/runner.rs` | `cont` mode loop + `resume` |
+| `src/iteration.rs` | `iter` mode loop |
 | `src/state.rs` | XDG state directory layout |
 | `src/preset.rs` | preset resolution + `{{var}}` substitution |
 | `src/notes.rs` | per-iteration learning generation |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Pursue a single open-ended goal on one working branch:
 
 ```sh
 # from inside a clean git repo
-kobito continuous --prompt "Increase test coverage in src/"
+kobito cont --prompt "Increase test coverage in src/"
 ```
 
 ### iteration
@@ -57,13 +57,13 @@ cat > .kobito/tasks.md <<'EOF'
 - [ ] Document the new endpoints in README
 EOF
 
-kobito iteration
+kobito iter
 ```
 
 Or point at an explicit backlog file:
 
 ```sh
-kobito iteration --backlog ./tasks.md
+kobito iter --backlog ./tasks.md
 ```
 
 The first run copies `.kobito/tasks.md` (or the file passed via `--backlog`)
@@ -94,7 +94,7 @@ Resolution checks (1) first, then (2). Missing preset → error.
 # Increase test coverage for {{path}}. Aim for {{target}}% line coverage.
 
 # preset replaces --prompt entirely:
-kobito continuous --preset coverage --var path=src/api --var target=80
+kobito cont --preset coverage --var path=src/api --var target=80
 ```
 
 In `continuous` mode `--preset` is **mutually exclusive with `--prompt`** — the resolved preset body becomes the goal.
@@ -102,7 +102,7 @@ In `continuous` mode `--preset` is **mutually exclusive with `--prompt`** — th
 In `iteration` mode each task in `tasks.md` is its own goal, so `--preset` instead acts as **framing prepended to every task prompt**:
 
 ```sh
-kobito iteration --preset small-feature --backlog tasks.md
+kobito iter --preset small-feature --backlog tasks.md
 ```
 
 ### Common options

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ the project's own conventions, until you stop it.
 
 ## Features
 
-- `continuous` mode — one branch, many commits, run until you stop it
-- `iteration` mode — per-task branch + PR from a `tasks.md` backlog
+- `cont` mode — one branch, many commits, run until you stop it
+- `iter` mode — per-task branch + PR from a `tasks.md` backlog
 - Claude Code and OpenAI Codex backends behind a single `Agent` trait
 - Preset system with `{{var}}` substitution (project + global)
 - Per-run `notes.md` auto-maintained by the agent
@@ -36,7 +36,7 @@ remote.
 
 ## Usage
 
-### continuous
+### cont
 
 Pursue a single open-ended goal on one working branch:
 
@@ -45,7 +45,7 @@ Pursue a single open-ended goal on one working branch:
 kobito cont --prompt "Increase test coverage in src/"
 ```
 
-### iteration
+### iter
 
 Consume a backlog of small tasks, one branch + PR per task:
 
@@ -97,9 +97,9 @@ Resolution checks (1) first, then (2). Missing preset → error.
 kobito cont --preset coverage --var path=src/api --var target=80
 ```
 
-In `continuous` mode `--preset` is **mutually exclusive with `--prompt`** — the resolved preset body becomes the goal.
+In `cont` mode `--preset` is **mutually exclusive with `--prompt`** — the resolved preset body becomes the goal.
 
-In `iteration` mode each task in `tasks.md` is its own goal, so `--preset` instead acts as **framing prepended to every task prompt**:
+In `iter` mode each task in `tasks.md` is its own goal, so `--preset` instead acts as **framing prepended to every task prompt**:
 
 ```sh
 kobito iter --preset small-feature --backlog tasks.md
@@ -109,8 +109,8 @@ kobito iter --preset small-feature --backlog tasks.md
 
 | flag                | default   | meaning                                     |
 | ------------------- | --------- | ------------------------------------------- |
-| `--prompt`, `-p`    | required (continuous) | the goal to pursue              |
-| `--backlog`         | optional (iteration)  | path to a tasks.md backlog      |
+| `--prompt`, `-p`    | required (cont) | the goal to pursue                    |
+| `--backlog`         | optional (iter)  | path to a tasks.md backlog           |
 | `--preset`          | optional  | preset name (resolved per the order above)  |
 | `--var key=value`   | repeatable | substitute `{{key}}` in the preset         |
 | `--max-iterations`  | `50` / `30` | hard cap on iterations (per task in iteration mode) |
@@ -135,7 +135,7 @@ kobito iter --preset small-feature --backlog tasks.md
 ```
 
 `notes.md` lives **per run**, not per project. Each invocation gets a
-fresh memory file, and iteration mode (which starts a new run per
+fresh memory file, and `iter` mode (which starts a new run per
 task) automatically gets a separate notes.md per task — coverage
 push and refactor learnings don't bleed into each other.
 
@@ -176,9 +176,9 @@ Each iteration:
 2. Invoke the agent in non-interactive mode, streaming stdout/stderr to the terminal and to `log.ndjson`. The agent loads its own `CLAUDE.md` / `AGENTS.md` at this point.
 3. If the agent emitted a diff, generate a Conventional Commits message via a one-shot agent call and commit.
 4. If the agent failed, `git reset --hard` and retry with exponential backoff.
-5. If the agent emits the literal sentinel token (`NATURAL_STOP` for continuous, `TASK_COMPLETE` for iteration), exit cleanly.
+5. If the agent emits the literal sentinel token (`NATURAL_STOP` for `cont`, `TASK_COMPLETE` for `iter`), exit cleanly.
 
-Single branch, single PR, many commits — by design (continuous mode). One branch + PR per task (iteration mode).
+Single branch, single PR, many commits — by design (`cont` mode). One branch + PR per task (`iter` mode).
 
 ## License
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,16 +18,18 @@ pub struct Cli {
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Run a never-ending goal on a single branch with many commits.
-    Continuous(ContinuousArgs),
+    #[command(alias = "continuous")]
+    Cont(ContinuousArgs),
     /// Consume a tasks.md backlog, one branch + PR per task.
-    Iteration(IterationArgs),
+    #[command(alias = "iteration")]
+    Iter(IterationArgs),
     /// List all known projects with their last run.
     Ls,
     /// Replay the last run's log for a project.
     Log { project: Option<String> },
-    /// Resume a previous continuous run (interactive picker, or --run <id>).
+    /// Resume a previous cont run (interactive picker, or --run <id>).
     Resume(ResumeArgs),
-    /// Manage the iteration backlog.
+    /// Manage the iter backlog.
     Tasks {
         #[command(subcommand)]
         action: TasksAction,
@@ -131,8 +133,8 @@ pub struct ContinuousArgs {
 
 pub async fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
-        Command::Continuous(args) => runner::run_continuous(args).await,
-        Command::Iteration(args) => iteration::run(args).await,
+        Command::Cont(args) => runner::run_continuous(args).await,
+        Command::Iter(args) => iteration::run(args).await,
         Command::Resume(args) => runner::resume_continuous(args).await,
         Command::Ls => crate::state::list_projects(),
         Command::Tasks {

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -111,10 +111,11 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                 consecutive_failures,
                 &format!("task {}/{}", task_idx, pending.len()),
             );
+            let notes = std::fs::read_to_string(state::notes_path(&run_dirs)).ok();
             let parts = prompt::PromptParts {
                 goal: body.clone(),
                 iteration,
-                notes: None,
+                notes,
                 preset: preset_body.clone(),
             };
             let prompt_body = prompt::build_task_prompt(&parts, body);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -9,8 +9,47 @@ pub struct PromptParts {
     pub preset: Option<String>,
 }
 
+const META_CONTINUOUS: &str = "\
+# About this run
+
+You are being driven by `kobito`, an autonomous orchestrator that spawns you in a loop. \
+Each invocation of you is one iteration:
+
+- The repo is checked out on a working branch dedicated to this run.
+- After this iteration finishes, the orchestrator stages any diff you produced and commits \
+  it with a generated message, then invokes a fresh you with the next iteration's prompt.
+- Use `git log` on the current branch to see what previous iterations of *this* run \
+  accomplished — your previous self has no in-process memory across iterations.
+- Any learnings you wrote in earlier iterations appear below under \"Cross-iteration notes\".
+- When the goal is fully reached or no meaningful work remains, output the literal token \
+  `NATURAL_STOP` on its own line and stop. The loop will exit cleanly. Otherwise make a \
+  small focused change and stop so it can be committed.
+
+";
+
+const META_ITERATION: &str = "\
+# About this run
+
+You are being driven by `kobito`, an autonomous orchestrator. This run focuses on **a single \
+task** picked from a backlog (`tasks.md`). Other tasks in the backlog are handled on \
+separate branches in separate runs — ignore them entirely, even if you notice issues that \
+could fix them.
+
+Each invocation of you is one iteration of this task's loop:
+
+- The repo is checked out on a working branch dedicated to this single task.
+- After this iteration finishes, the orchestrator stages any diff you produced and commits \
+  it with a generated message, then invokes a fresh you with the next iteration's prompt.
+- Use `git log` on the current branch to see what previous iterations of *this* task \
+  accomplished — your previous self has no in-process memory across iterations.
+- Any learnings you wrote in earlier iterations appear below under \"Cross-iteration notes\".
+- When the task is fully complete, output the literal token `TASK_COMPLETE` on its own \
+  line and stop. The loop will move on to the next task.
+
+";
+
 pub fn build_iteration_prompt(parts: &PromptParts) -> String {
-    let mut out = String::new();
+    let mut out = String::from(META_CONTINUOUS);
 
     if let Some(preset) = &parts.preset {
         out.push_str(preset.trim());
@@ -32,18 +71,25 @@ pub fn build_iteration_prompt(parts: &PromptParts) -> String {
     ));
 
     out.push_str(
-        "Make a small, self-contained improvement toward the goal. Stop when one logical change is complete so the diff can be committed. \
-        If the goal is already fully achieved or no meaningful work remains, reply with the literal token NATURAL_STOP and make no changes.\n",
+        "Make a small, self-contained improvement toward the goal. Stop when one logical change is complete so the diff can be committed.\n",
     );
 
     out
 }
 
 pub fn build_task_prompt(parts: &PromptParts, task_body: &str) -> String {
-    let mut out = String::new();
+    let mut out = String::from(META_ITERATION);
 
     if let Some(preset) = &parts.preset {
         out.push_str(preset.trim());
+        out.push_str("\n\n");
+    }
+
+    if let Some(notes) = &parts.notes
+        && !notes.trim().is_empty()
+    {
+        out.push_str("## Cross-iteration notes\n\n");
+        out.push_str(notes.trim());
         out.push_str("\n\n");
     }
 
@@ -54,10 +100,7 @@ pub fn build_task_prompt(parts: &PromptParts, task_body: &str) -> String {
     ));
 
     out.push_str(
-        "Make focused progress toward completing only this single task. \
-         When the task is fully complete and no more work remains for it, \
-         output the literal token TASK_COMPLETE on its own line and stop. \
-         Do not start unrelated work even if you notice other issues — they belong to other tasks.\n",
+        "Make focused progress toward completing only this single task. Stop when one logical change is complete so the diff can be committed.\n",
     );
 
     out


### PR DESCRIPTION
## Summary

Shorter subcommand names. Old names remain accepted as clap aliases — `kobito continuous --prompt ...` still works alongside the new `kobito cont --prompt ...`.

```
kobito cont --prompt "Increase test coverage in src/api"
kobito iter --backlog tasks.md
```

Internal type names (`ContinuousArgs`, `IterationArgs`) and module names (`runner`, `iteration`) are kept — the rename is purely on the user-facing CLI surface and the docs that describe it.

## Commits

| # | commit |
|---|--------|
| 1 | feat(cli): rename continuous/iteration subcommands to cont/iter |
| 2 | docs: finish renaming continuous/iteration in README |

## Test plan

- [ ] `kobito --help` lists `cont` and `iter`
- [ ] `kobito cont --help` works
- [ ] `kobito continuous --help` still works (alias)
- [ ] `kobito iter --help` works
- [ ] `kobito iteration --help` still works (alias)
- [ ] `cargo test` green