### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

Enable Dependabot for two ecosystems:

- `cargo` — keeps `Cargo.toml` / `Cargo.lock` deps current
- `github-actions` — keeps `actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache` etc. current

Both run **weekly** with up to 5 open PRs each. PRs land with `chore(deps): ...` titles to match the AGENTS.md commit format and are labelled `dependencies`.

## Test plan

- [ ] After merge, the Dependabot tab on github.com starts listing both ecosystems
- [ ] First weekly run opens at most 5 cargo PRs and 5 github-actions PRs (likely fewer)
- [ ] Each PR title looks like `chore(deps): bump <name> from x.y.z to x.y.w`