### PR TITLE
feat(agent): structured streaming with AgentEvent + JSON parsers + token usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ An autonomous coding agent orchestrator. Spawns `claude` or `codex` CLI in a loo
 |---|---|
 | `src/main.rs` | entry point — `mod` declarations only |
 | `src/cli.rs` | clap definitions + dispatch |
-| `src/agent/` | `Agent` trait + per-agent modules (`claude_code`, `codex`) and shared `stream` helper |
+| `src/agent/` | `Agent` trait + per-agent modules (`claude_code`, `codex`), shared `stream` helper, and the normalised `AgentEvent` / `Usage` types in `event.rs` |
 | `src/runner.rs` | `cont` mode loop + `resume` |
 | `src/iteration.rs` | `iter` mode loop |
 | `src/state.rs` | XDG state directory layout |
@@ -27,7 +27,7 @@ An autonomous coding agent orchestrator. Spawns `claude` or `codex` CLI in a loo
 | `src/branch.rs` | agent-driven branch name suggestion |
 | `src/commit.rs` | agent-driven commit message generation |
 | `src/git.rs` | `git` CLI wrapper |
-| `src/logger.rs` | `LogSink` — terminal passthrough + ndjson |
+| `src/logger.rs` | `LogSink` — terminal passthrough + per-run `log.ndjson` (human-readable lines) and `events.ndjson` (raw `AgentEvent` JSON) |
 | `src/ui.rs` | indicatif status bar |
 | `src/prompt.rs` | iteration / task prompt builders |
 | `src/tasks.rs` | `tasks.md` parser |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ the project's own conventions, until you stop it.
 - Preset system with `{{var}}` substitution (project + global)
 - Per-run `notes.md` auto-maintained by the agent
 - `kobito resume` with an interactive picker of recent runs
-- State under `$XDG_STATE_HOME/kobito/`, real-time log passthrough + status bar
+- State under `$XDG_STATE_HOME/kobito/`, event-driven streaming + status bar
+- Per-iteration token usage logged from each agent's structured event stream
 
 Project conventions — output language, code style, commit format, branch
 names — are deferred to the agent's own memory files (`CLAUDE.md` /
@@ -129,7 +130,8 @@ kobito iter --preset small-feature --backlog tasks.md
             └── 2026-05-01T12-00-00/   # one directory per invocation = run id
                 ├── meta.json       # branch, goal, agent — used for resume
                 ├── notes.md        # cross-iteration learnings, agent-maintained
-                ├── log.ndjson      # streamed agent output
+                ├── log.ndjson      # human-readable streamed lines
+                ├── events.ndjson   # raw structured events from the agent
                 └── prompts/
                     └── iter-0001.md
 ```
@@ -173,7 +175,7 @@ the earlier iterations learned.
 Each iteration:
 
 1. Build a prompt: cross-iteration notes (if any) + the goal + a `NATURAL_STOP` / `TASK_COMPLETE` escape hatch.
-2. Invoke the agent in non-interactive mode, streaming stdout/stderr to the terminal and to `log.ndjson`. The agent loads its own `CLAUDE.md` / `AGENTS.md` at this point.
+2. Invoke the agent in non-interactive mode with its structured-output flag (`claude --output-format stream-json` / `codex exec --json`). Each line is parsed into a normalised `AgentEvent` (Message / ToolStart / ToolEnd / Usage / Stop / Other), formatted onto the terminal, and persisted both as a human-readable line in `log.ndjson` and as a raw JSON event in `events.ndjson`. The agent loads its own `CLAUDE.md` / `AGENTS.md` at this point.
 3. If the agent emitted a diff, generate a Conventional Commits message via a one-shot agent call and commit.
 4. If the agent failed, `git reset --hard` and retry with exponential backoff.
 5. If the agent emits the literal sentinel token (`NATURAL_STOP` for `cont`, `TASK_COMPLETE` for `iter`), exit cleanly.

--- a/src/agent/claude_code.rs
+++ b/src/agent/claude_code.rs
@@ -1,6 +1,7 @@
 use tokio::process::Command;
 
 use super::Agent;
+use super::event::AgentEvent;
 
 pub struct ClaudeCode;
 
@@ -17,7 +18,9 @@ impl Agent for ClaudeCode {
             "--permission-mode",
             "bypassPermissions",
             "--output-format",
-            "text",
+            "stream-json",
+            "--include-partial-messages",
+            "--verbose",
         ]);
         cmd
     }
@@ -26,5 +29,73 @@ impl Agent for ClaudeCode {
         let mut cmd = Command::new("claude");
         cmd.args(["-p", prompt, "--output-format", "text"]);
         cmd
+    }
+
+    fn parse_event(&self, line: &str) -> AgentEvent {
+        parse(line).unwrap_or_else(|| AgentEvent::Other(line.to_string()))
+    }
+}
+
+fn parse(line: &str) -> Option<AgentEvent> {
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let kind = v.get("type")?.as_str()?;
+    match kind {
+        "message_start" => {
+            let usage = v.get("message")?.get("usage")?;
+            Some(AgentEvent::Usage(super::event::Usage {
+                input_tokens: usage
+                    .get("input_tokens")
+                    .and_then(|n| n.as_u64())
+                    .unwrap_or(0),
+                output_tokens: usage
+                    .get("output_tokens")
+                    .and_then(|n| n.as_u64())
+                    .unwrap_or(0),
+                cached_input_tokens: usage
+                    .get("cache_read_input_tokens")
+                    .and_then(|n| n.as_u64())
+                    .unwrap_or(0),
+            }))
+        }
+        "content_block_start" => {
+            let block = v.get("content_block")?;
+            let block_type = block.get("type")?.as_str()?;
+            if block_type == "tool_use" || block_type == "server_tool_use" {
+                let tool = block
+                    .get("name")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                Some(AgentEvent::ToolStart {
+                    tool,
+                    summary: None,
+                })
+            } else {
+                None
+            }
+        }
+        "content_block_delta" => {
+            let delta = v.get("delta")?;
+            let delta_type = delta.get("type")?.as_str()?;
+            if delta_type == "text_delta" {
+                let text = delta.get("text")?.as_str()?.to_string();
+                Some(AgentEvent::Message(text))
+            } else {
+                None
+            }
+        }
+        "message_delta" => {
+            let usage = v.get("usage")?;
+            let output_tokens = usage.get("output_tokens").and_then(|n| n.as_u64())?;
+            Some(AgentEvent::Usage(super::event::Usage {
+                input_tokens: 0,
+                output_tokens,
+                cached_input_tokens: 0,
+            }))
+        }
+        "message_stop" => Some(AgentEvent::Stop {
+            reason: "end".to_string(),
+        }),
+        _ => None,
     }
 }

--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -1,6 +1,7 @@
 use tokio::process::Command;
 
 use super::Agent;
+use super::event::AgentEvent;
 
 pub struct Codex;
 
@@ -14,8 +15,7 @@ impl Agent for Codex {
         cmd.args([
             "exec",
             "--dangerously-bypass-approvals-and-sandbox",
-            "--color",
-            "never",
+            "--json",
             prompt,
         ]);
         cmd
@@ -25,5 +25,91 @@ impl Agent for Codex {
         let mut cmd = Command::new("codex");
         cmd.args(["exec", "--color", "never", prompt]);
         cmd
+    }
+
+    fn parse_event(&self, line: &str) -> AgentEvent {
+        parse(line).unwrap_or_else(|| AgentEvent::Other(line.to_string()))
+    }
+}
+
+fn parse(line: &str) -> Option<AgentEvent> {
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let kind = v.get("type")?.as_str()?;
+    match kind {
+        "item.completed" => {
+            let item = v.get("item")?;
+            let item_type = item.get("type")?.as_str()?;
+            match item_type {
+                "agent_message" => {
+                    let text = item.get("text")?.as_str()?.to_string();
+                    Some(AgentEvent::Message(text))
+                }
+                "command_execution" | "tool_call" | "function_call" => {
+                    let tool = item
+                        .get("name")
+                        .or_else(|| item.get("command"))
+                        .and_then(|s| s.as_str())
+                        .unwrap_or(item_type)
+                        .to_string();
+                    let summary = item
+                        .get("command")
+                        .and_then(|s| s.as_str())
+                        .map(|s| s.to_string());
+                    Some(AgentEvent::ToolEnd {
+                        tool: format!("{tool}: {}", summary.clone().unwrap_or_default())
+                            .trim_end_matches(": ")
+                            .to_string(),
+                        ok: item
+                            .get("exit_code")
+                            .and_then(|n| n.as_i64())
+                            .map(|c| c == 0)
+                            .unwrap_or(true),
+                    })
+                }
+                _ => None,
+            }
+        }
+        "item.started" => {
+            let item = v.get("item")?;
+            let item_type = item.get("type")?.as_str()?;
+            if matches!(
+                item_type,
+                "command_execution" | "tool_call" | "function_call"
+            ) {
+                let tool = item
+                    .get("name")
+                    .or_else(|| item.get("command"))
+                    .and_then(|s| s.as_str())
+                    .unwrap_or(item_type)
+                    .to_string();
+                Some(AgentEvent::ToolStart {
+                    tool,
+                    summary: item
+                        .get("command")
+                        .and_then(|s| s.as_str())
+                        .map(|s| s.to_string()),
+                })
+            } else {
+                None
+            }
+        }
+        "turn.completed" => {
+            let usage = v.get("usage")?;
+            Some(AgentEvent::Usage(super::event::Usage {
+                input_tokens: usage
+                    .get("input_tokens")
+                    .and_then(|n| n.as_u64())
+                    .unwrap_or(0),
+                output_tokens: usage
+                    .get("output_tokens")
+                    .and_then(|n| n.as_u64())
+                    .unwrap_or(0),
+                cached_input_tokens: usage
+                    .get("cached_input_tokens")
+                    .and_then(|n| n.as_u64())
+                    .unwrap_or(0),
+            }))
+        }
+        _ => None,
     }
 }

--- a/src/agent/event.rs
+++ b/src/agent/event.rs
@@ -1,0 +1,32 @@
+/// A normalized event produced by an agent's streaming output.
+///
+/// Each `Agent` impl maps its native streaming format (Claude Code's
+/// `stream-json`, Codex's `--json`, …) into this enum so the rest of
+/// kobito can render and persist agent activity uniformly.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum AgentEvent {
+    /// A piece of agent-emitted text. May arrive as a complete block or
+    /// as an incremental chunk; the consumer concatenates.
+    Message(String),
+    /// A tool invocation started.
+    ToolStart {
+        tool: String,
+        summary: Option<String>,
+    },
+    /// A tool invocation completed.
+    ToolEnd { tool: String, ok: bool },
+    /// Cumulative token usage update.
+    Usage(Usage),
+    /// The run is wrapping up with a stop reason.
+    Stop { reason: String },
+    /// An unrecognised line, kept verbatim for debugging.
+    Other(String),
+}
+
+#[derive(Debug, Clone, Default, Copy)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cached_input_tokens: u64,
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,14 +5,17 @@ use crate::logger::LogSink;
 
 mod claude_code;
 mod codex;
+mod event;
 mod stream;
 
+pub use event::{AgentEvent, Usage};
 pub use stream::AgentOutcome;
 
 pub trait Agent: Send + Sync {
     fn name(&self) -> &str;
     fn build_streaming_command(&self, prompt: &str) -> tokio::process::Command;
     fn build_oneshot_command(&self, prompt: &str) -> tokio::process::Command;
+    fn parse_event(&self, line: &str) -> AgentEvent;
 }
 
 pub fn from_name(name: &str) -> Result<Box<dyn Agent>> {
@@ -31,7 +34,7 @@ pub async fn run(
 ) -> Result<AgentOutcome> {
     let mut cmd = agent.build_streaming_command(prompt);
     cmd.current_dir(repo);
-    stream::run_streamed(cmd, agent.name(), sink).await
+    stream::run_streamed(cmd, agent, sink).await
 }
 
 pub async fn run_oneshot(agent: &dyn Agent, repo: &Path, prompt: &str) -> Result<String> {

--- a/src/agent/stream.rs
+++ b/src/agent/stream.rs
@@ -3,33 +3,31 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
+use super::Agent;
+use super::event::{AgentEvent, Usage};
 use crate::logger::LogSink;
 
 pub struct AgentOutcome {
+    #[allow(dead_code)]
     pub stdout: String,
     pub natural_stop: bool,
+    pub task_complete: bool,
+    pub usage: Usage,
 }
 
-pub async fn run_streamed(mut cmd: Command, name: &str, sink: &LogSink) -> Result<AgentOutcome> {
+pub async fn run_streamed(
+    mut cmd: Command,
+    agent: &dyn Agent,
+    sink: &LogSink,
+) -> Result<AgentOutcome> {
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let name = agent.name().to_string();
     let mut child = cmd
         .spawn()
         .with_context(|| format!("spawn {name} — is the `{name}` CLI installed and on PATH?"))?;
 
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
-
-    let stdout_sink = sink.clone();
-    let stdout_task = tokio::spawn(async move {
-        let mut buf = String::new();
-        let mut reader = BufReader::new(stdout).lines();
-        while let Ok(Some(line)) = reader.next_line().await {
-            stdout_sink.write("stdout", &line);
-            buf.push_str(&line);
-            buf.push('\n');
-        }
-        buf
-    });
 
     let stderr_sink = sink.clone();
     let stderr_task = tokio::spawn(async move {
@@ -39,17 +37,37 @@ pub async fn run_streamed(mut cmd: Command, name: &str, sink: &LogSink) -> Resul
         }
     });
 
+    let mut accumulated = String::new();
+    let mut usage = Usage::default();
+    let mut reader = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = reader.next_line().await {
+        let event = agent.parse_event(&line);
+        sink.event(&line, &event);
+        match &event {
+            AgentEvent::Message(text) => {
+                accumulated.push_str(text);
+                accumulated.push('\n');
+            }
+            AgentEvent::Usage(u) => {
+                usage = *u;
+            }
+            _ => {}
+        }
+    }
+
     let status = child.wait().await?;
-    let captured = stdout_task.await.unwrap_or_default();
     let _ = stderr_task.await;
 
     if !status.success() {
         bail!("{name} exited with status {status}");
     }
-    let natural_stop = captured.contains("NATURAL_STOP");
+    let natural_stop = accumulated.contains("NATURAL_STOP");
+    let task_complete = accumulated.contains("TASK_COMPLETE");
     Ok(AgentOutcome {
-        stdout: captured,
+        stdout: accumulated,
         natural_stop,
+        task_complete,
+        usage,
     })
 }
 

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -153,7 +153,13 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                     } else {
                         sink.note("no diff this iteration");
                     }
-                    if out.stdout.contains("TASK_COMPLETE") {
+                    sink.note(&format!(
+                        "  tokens — in {} · out {} · cached {}",
+                        out.usage.input_tokens,
+                        out.usage.output_tokens,
+                        out.usage.cached_input_tokens,
+                    ));
+                    if out.task_complete {
                         sink.note("agent reported TASK_COMPLETE");
                         completed = true;
                         break;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,6 +8,8 @@ use std::sync::{Arc, Mutex};
 
 use indicatif::ProgressBar;
 
+use crate::agent::AgentEvent;
+
 #[derive(Serialize)]
 struct LogLine<'a> {
     ts: String,
@@ -15,20 +17,33 @@ struct LogLine<'a> {
     line: &'a str,
 }
 
+#[derive(Serialize)]
+struct EventLine<'a> {
+    ts: String,
+    raw: &'a str,
+}
+
 #[derive(Clone)]
 pub struct LogSink {
-    inner: Arc<Mutex<File>>,
+    log: Arc<Mutex<File>>,
+    events: Arc<Mutex<File>>,
     bar: Option<ProgressBar>,
 }
 
 impl LogSink {
     pub fn open(log_path: &Path, bar: Option<ProgressBar>) -> Result<Self> {
-        let file = OpenOptions::new()
+        let log = OpenOptions::new()
             .create(true)
             .append(true)
             .open(log_path)?;
+        let events_path = log_path.with_file_name("events.ndjson");
+        let events = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(events_path)?;
         Ok(Self {
-            inner: Arc::new(Mutex::new(file)),
+            log: Arc::new(Mutex::new(log)),
+            events: Arc::new(Mutex::new(events)),
             bar,
         })
     }
@@ -40,18 +55,60 @@ impl LogSink {
             line,
         };
         if let Ok(json) = serde_json::to_string(&entry)
-            && let Ok(mut f) = self.inner.lock()
+            && let Ok(mut f) = self.log.lock()
         {
             let _ = writeln!(f, "{json}");
         }
+        self.print(line);
+    }
+
+    pub fn note(&self, line: &str) {
+        self.write("kobito", line);
+    }
+
+    pub fn event(&self, raw: &str, event: &AgentEvent) {
+        if let Ok(json) = serde_json::to_string(&EventLine {
+            ts: Utc::now().to_rfc3339(),
+            raw,
+        }) && let Ok(mut f) = self.events.lock()
+        {
+            let _ = writeln!(f, "{json}");
+        }
+        if let Some(formatted) = format_event(event) {
+            self.print(&formatted);
+        }
+    }
+
+    fn print(&self, line: &str) {
         if let Some(bar) = &self.bar {
             bar.println(format!("│ {line}"));
         } else {
             println!("{line}");
         }
     }
+}
 
-    pub fn note(&self, line: &str) {
-        self.write("kobito", line);
+fn format_event(event: &AgentEvent) -> Option<String> {
+    match event {
+        AgentEvent::Message(text) => {
+            let trimmed = text.trim_end_matches('\n');
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        AgentEvent::ToolStart { tool, summary } => Some(match summary {
+            Some(s) => format!("▶ {tool}: {s}"),
+            None => format!("▶ {tool}"),
+        }),
+        AgentEvent::ToolEnd { tool, ok } => Some(if *ok {
+            format!("✓ {tool}")
+        } else {
+            format!("✗ {tool}")
+        }),
+        AgentEvent::Stop { reason } => Some(format!("(stop: {reason})")),
+        AgentEvent::Usage(_) => None,
+        AgentEvent::Other(_) => None,
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -230,6 +230,8 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
                 git::commit(args.repo, &msg)?;
                 args.sink
                     .note(&format!("✓ committed: {}", first_line(&msg)));
+                args.sink
+                    .note(&format!("  tokens — {}", format_usage(&out.usage)));
                 completed += 1;
 
                 let notes_path = state::notes_path(args.run);
@@ -310,4 +312,23 @@ fn slugify(s: &str) -> String {
 
 fn first_line(s: &str) -> &str {
     s.lines().next().unwrap_or("")
+}
+
+fn format_usage(u: &crate::agent::Usage) -> String {
+    format!(
+        "in {} · out {} · cached {}",
+        format_count(u.input_tokens),
+        format_count(u.output_tokens),
+        format_count(u.cached_input_tokens),
+    )
+}
+
+fn format_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
 }


### PR DESCRIPTION
## Summary

Both agent backends now stream **structured JSON events** instead of plain text. A normalised `AgentEvent` enum sits between the agent and the rest of kobito so we can render and persist activity uniformly:

- `Message(String)` — agent text (streamed text_delta for Claude, agent_message for Codex)
- `ToolStart { tool, summary }` / `ToolEnd { tool, ok }` — tool / command invocations
- `Usage(Usage)` — cumulative token counts (input / output / cached)
- `Stop { reason }` — run is wrapping up
- `Other(String)` — anything we did not recognise, kept verbatim

CLI flags switched:
- `claude -p ... --output-format stream-json --include-partial-messages`
- `codex exec --json ...`

## What lands per iteration

```
│ ▶ Bash: cargo test
│ ✓ Bash
│ <message text>
│ ✓ committed: feat(api): add /healthz endpoint
│   tokens — in 1.2k · out 340 · cached 8.5k
```

Every line is also persisted in two ndjson files in the run dir:

```
runs/<ts>/log.ndjson      # human-readable streamed lines (existing)
runs/<ts>/events.ndjson   # raw agent JSON, one event per line (new)
```

`events.ndjson` keeps the original schema-as-emitted so debug tooling can rerun it through any parser.

## Commits

| # | commit |
|---|--------|
| 1 | feat(agent): structured streaming with AgentEvent and JSON parsers |
| 2 | feat(runner): print per-iteration token usage |
| 3 | docs: describe structured streaming + events.ndjson |

## Test plan

- [ ] `cargo test --bin kobito` — 18 tests green
- [ ] `cargo build --release`
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] On a sample repo, `kobito cont --prompt "..."` shows tool starts/ends + per-iteration token counts
- [ ] `runs/<ts>/events.ndjson` contains valid JSON lines from the agent
- [ ] `kobito cont --agent codex --prompt "..."` produces the same shape