### PR TITLE
fix(agent): make the streaming feed actually readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "console",
  "ctrlc",
  "dialoguer",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+console = "0.15"
 ctrlc = "3"
 dialoguer = { version = "0.11", default-features = false }
 dirs = "5"

--- a/src/agent/claude_code.rs
+++ b/src/agent/claude_code.rs
@@ -35,11 +35,14 @@ impl ClaudeCode {
     }
 
     fn resolve_tool(&self, id: &str) -> String {
-        self.tools
-            .lock()
-            .ok()
-            .and_then(|m| m.get(id).cloned())
-            .unwrap_or_else(|| "tool".to_string())
+        // Remove rather than read so the map doesn't grow unbounded
+        // across iterations and a stale tool_use_id can't be matched
+        // against a freshly issued one with the same suffix.
+        if let Ok(mut m) = self.tools.lock() {
+            m.remove(id).unwrap_or_else(|| "tool".to_string())
+        } else {
+            "tool".to_string()
+        }
     }
 }
 

--- a/src/agent/claude_code.rs
+++ b/src/agent/claude_code.rs
@@ -1,7 +1,7 @@
 use tokio::process::Command;
 
 use super::Agent;
-use super::event::AgentEvent;
+use super::event::{AgentEvent, Usage};
 
 pub struct ClaudeCode;
 
@@ -19,7 +19,6 @@ impl Agent for ClaudeCode {
             "bypassPermissions",
             "--output-format",
             "stream-json",
-            "--include-partial-messages",
             "--verbose",
         ]);
         cmd
@@ -40,62 +39,90 @@ fn parse(line: &str) -> Option<AgentEvent> {
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     let kind = v.get("type")?.as_str()?;
     match kind {
+        "stream_event" => parse_stream_event(v.get("event")?),
+        "user" => parse_user_message(v.get("message")?),
+        "assistant" => parse_assistant_message(v.get("message")?),
+        "result" => Some(AgentEvent::Stop {
+            reason: v
+                .get("subtype")
+                .and_then(|s| s.as_str())
+                .unwrap_or("end")
+                .to_string(),
+        }),
+        _ => None,
+    }
+}
+
+fn parse_stream_event(event: &serde_json::Value) -> Option<AgentEvent> {
+    let kind = event.get("type")?.as_str()?;
+    match kind {
         "message_start" => {
-            let usage = v.get("message")?.get("usage")?;
-            Some(AgentEvent::Usage(super::event::Usage {
-                input_tokens: usage
-                    .get("input_tokens")
-                    .and_then(|n| n.as_u64())
-                    .unwrap_or(0),
-                output_tokens: usage
-                    .get("output_tokens")
-                    .and_then(|n| n.as_u64())
-                    .unwrap_or(0),
-                cached_input_tokens: usage
-                    .get("cache_read_input_tokens")
-                    .and_then(|n| n.as_u64())
-                    .unwrap_or(0),
-            }))
+            let usage = event.get("message")?.get("usage")?;
+            Some(AgentEvent::Usage(usage_from(usage)))
         }
         "content_block_start" => {
-            let block = v.get("content_block")?;
+            let block = event.get("content_block")?;
             let block_type = block.get("type")?.as_str()?;
-            if block_type == "tool_use" || block_type == "server_tool_use" {
-                let tool = block
-                    .get("name")
-                    .and_then(|s| s.as_str())
-                    .unwrap_or("unknown")
-                    .to_string();
-                Some(AgentEvent::ToolStart {
-                    tool,
-                    summary: None,
-                })
-            } else {
-                None
+            match block_type {
+                "tool_use" | "server_tool_use" => {
+                    let tool = block
+                        .get("name")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+                    Some(AgentEvent::ToolStart {
+                        tool,
+                        summary: None,
+                    })
+                }
+                _ => None,
             }
         }
-        "content_block_delta" => {
-            let delta = v.get("delta")?;
-            let delta_type = delta.get("type")?.as_str()?;
-            if delta_type == "text_delta" {
-                let text = delta.get("text")?.as_str()?.to_string();
-                Some(AgentEvent::Message(text))
-            } else {
-                None
-            }
-        }
-        "message_delta" => {
-            let usage = v.get("usage")?;
-            let output_tokens = usage.get("output_tokens").and_then(|n| n.as_u64())?;
-            Some(AgentEvent::Usage(super::event::Usage {
-                input_tokens: 0,
-                output_tokens,
-                cached_input_tokens: 0,
-            }))
-        }
+        "content_block_delta" => None,
+        "message_delta" => event.get("usage").map(|u| AgentEvent::Usage(usage_from(u))),
         "message_stop" => Some(AgentEvent::Stop {
             reason: "end".to_string(),
         }),
         _ => None,
+    }
+}
+
+fn parse_user_message(message: &serde_json::Value) -> Option<AgentEvent> {
+    let content = message.get("content")?.as_array()?;
+    for item in content {
+        if item.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+            let is_error = item
+                .get("is_error")
+                .and_then(|b| b.as_bool())
+                .unwrap_or(false);
+            return Some(AgentEvent::ToolEnd {
+                tool: "tool".to_string(),
+                ok: !is_error,
+            });
+        }
+    }
+    None
+}
+
+fn parse_assistant_message(message: &serde_json::Value) -> Option<AgentEvent> {
+    let content = message.get("content")?.as_array()?;
+    for item in content {
+        if item.get("type").and_then(|t| t.as_str()) == Some("text")
+            && let Some(text) = item.get("text").and_then(|s| s.as_str())
+        {
+            return Some(AgentEvent::Message(text.to_string()));
+        }
+    }
+    None
+}
+
+fn usage_from(v: &serde_json::Value) -> Usage {
+    Usage {
+        input_tokens: v.get("input_tokens").and_then(|n| n.as_u64()).unwrap_or(0),
+        output_tokens: v.get("output_tokens").and_then(|n| n.as_u64()).unwrap_or(0),
+        cached_input_tokens: v
+            .get("cache_read_input_tokens")
+            .and_then(|n| n.as_u64())
+            .unwrap_or(0),
     }
 }

--- a/src/agent/claude_code.rs
+++ b/src/agent/claude_code.rs
@@ -1,9 +1,47 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
 use tokio::process::Command;
 
 use super::Agent;
 use super::event::{AgentEvent, Usage};
 
-pub struct ClaudeCode;
+/// Claude Code's `--output-format stream-json` emits `assistant` /
+/// `user` / `result` envelope lines. tool_use entries inside an
+/// `assistant` message carry a unique id, and the matching
+/// `tool_result` inside the next `user` message references that id —
+/// not the tool name. We track the mapping here so a tool_result can
+/// be reported with the original tool name.
+pub struct ClaudeCode {
+    tools: Mutex<HashMap<String, String>>,
+}
+
+impl Default for ClaudeCode {
+    fn default() -> Self {
+        Self {
+            tools: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl ClaudeCode {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn remember_tool(&self, id: &str, name: &str) {
+        if let Ok(mut m) = self.tools.lock() {
+            m.insert(id.to_string(), name.to_string());
+        }
+    }
+
+    fn resolve_tool(&self, id: &str) -> String {
+        self.tools
+            .lock()
+            .ok()
+            .and_then(|m| m.get(id).cloned())
+            .unwrap_or_else(|| "tool".to_string())
+    }
+}
 
 impl Agent for ClaudeCode {
     fn name(&self) -> &str {
@@ -30,90 +68,133 @@ impl Agent for ClaudeCode {
         cmd
     }
 
-    fn parse_event(&self, line: &str) -> AgentEvent {
-        parse(line).unwrap_or_else(|| AgentEvent::Other(line.to_string()))
-    }
-}
-
-fn parse(line: &str) -> Option<AgentEvent> {
-    let v: serde_json::Value = serde_json::from_str(line).ok()?;
-    let kind = v.get("type")?.as_str()?;
-    match kind {
-        "stream_event" => parse_stream_event(v.get("event")?),
-        "user" => parse_user_message(v.get("message")?),
-        "assistant" => parse_assistant_message(v.get("message")?),
-        "result" => Some(AgentEvent::Stop {
-            reason: v
-                .get("subtype")
-                .and_then(|s| s.as_str())
-                .unwrap_or("end")
-                .to_string(),
-        }),
-        _ => None,
-    }
-}
-
-fn parse_stream_event(event: &serde_json::Value) -> Option<AgentEvent> {
-    let kind = event.get("type")?.as_str()?;
-    match kind {
-        "message_start" => {
-            let usage = event.get("message")?.get("usage")?;
-            Some(AgentEvent::Usage(usage_from(usage)))
+    fn parse_event(&self, line: &str) -> Vec<AgentEvent> {
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => return vec![AgentEvent::Other(line.to_string())],
+        };
+        let kind = match v.get("type").and_then(|t| t.as_str()) {
+            Some(k) => k,
+            None => return vec![],
+        };
+        match kind {
+            "assistant" => self.parse_assistant(v.get("message")),
+            "user" => self.parse_user(v.get("message")),
+            "result" => parse_result(&v),
+            "stream_event" => parse_stream_event(v.get("event")),
+            _ => vec![],
         }
-        "content_block_start" => {
-            let block = event.get("content_block")?;
-            let block_type = block.get("type")?.as_str()?;
-            match block_type {
-                "tool_use" | "server_tool_use" => {
-                    let tool = block
+    }
+}
+
+impl ClaudeCode {
+    fn parse_assistant(&self, message: Option<&serde_json::Value>) -> Vec<AgentEvent> {
+        let content = match message
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
+        {
+            Some(c) => c,
+            None => return vec![],
+        };
+        let mut out = vec![];
+        for item in content {
+            let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            match item_type {
+                "text" => {
+                    if let Some(text) = item.get("text").and_then(|s| s.as_str())
+                        && !text.trim().is_empty()
+                    {
+                        out.push(AgentEvent::Message(text.to_string()));
+                    }
+                }
+                "tool_use" => {
+                    let id = item
+                        .get("id")
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let tool = item
                         .get("name")
                         .and_then(|s| s.as_str())
                         .unwrap_or("unknown")
                         .to_string();
-                    Some(AgentEvent::ToolStart {
-                        tool,
-                        summary: None,
-                    })
+                    if !id.is_empty() {
+                        self.remember_tool(&id, &tool);
+                    }
+                    let summary = summarize_tool_input(item.get("input"));
+                    out.push(AgentEvent::ToolStart { tool, summary });
                 }
-                _ => None,
+                _ => {}
             }
         }
-        "content_block_delta" => None,
-        "message_delta" => event.get("usage").map(|u| AgentEvent::Usage(usage_from(u))),
-        "message_stop" => Some(AgentEvent::Stop {
-            reason: "end".to_string(),
-        }),
-        _ => None,
+        out
     }
-}
 
-fn parse_user_message(message: &serde_json::Value) -> Option<AgentEvent> {
-    let content = message.get("content")?.as_array()?;
-    for item in content {
-        if item.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
-            let is_error = item
-                .get("is_error")
-                .and_then(|b| b.as_bool())
-                .unwrap_or(false);
-            return Some(AgentEvent::ToolEnd {
-                tool: "tool".to_string(),
-                ok: !is_error,
-            });
-        }
-    }
-    None
-}
-
-fn parse_assistant_message(message: &serde_json::Value) -> Option<AgentEvent> {
-    let content = message.get("content")?.as_array()?;
-    for item in content {
-        if item.get("type").and_then(|t| t.as_str()) == Some("text")
-            && let Some(text) = item.get("text").and_then(|s| s.as_str())
+    fn parse_user(&self, message: Option<&serde_json::Value>) -> Vec<AgentEvent> {
+        let content = match message
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
         {
-            return Some(AgentEvent::Message(text.to_string()));
+            Some(c) => c,
+            None => return vec![],
+        };
+        let mut out = vec![];
+        for item in content {
+            if item.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                let id = item
+                    .get("tool_use_id")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("");
+                let tool = self.resolve_tool(id);
+                let is_error = item
+                    .get("is_error")
+                    .and_then(|b| b.as_bool())
+                    .unwrap_or(false);
+                out.push(AgentEvent::ToolEnd {
+                    tool,
+                    ok: !is_error,
+                });
+            }
         }
+        out
     }
-    None
+}
+
+fn parse_result(v: &serde_json::Value) -> Vec<AgentEvent> {
+    let mut out = vec![];
+    if let Some(usage) = v.get("usage") {
+        out.push(AgentEvent::Usage(usage_from(usage)));
+    }
+    let reason = v
+        .get("subtype")
+        .and_then(|s| s.as_str())
+        .unwrap_or("end")
+        .to_string();
+    out.push(AgentEvent::Stop { reason });
+    out
+}
+
+fn parse_stream_event(event: Option<&serde_json::Value>) -> Vec<AgentEvent> {
+    let event = match event {
+        Some(e) => e,
+        None => return vec![],
+    };
+    let kind = match event.get("type").and_then(|t| t.as_str()) {
+        Some(k) => k,
+        None => return vec![],
+    };
+    match kind {
+        "message_start" => event
+            .get("message")
+            .and_then(|m| m.get("usage"))
+            .map(|u| vec![AgentEvent::Usage(usage_from(u))])
+            .unwrap_or_default(),
+        "message_delta" => event
+            .get("usage")
+            .map(|u| vec![AgentEvent::Usage(usage_from(u))])
+            .unwrap_or_default(),
+        _ => vec![],
+    }
 }
 
 fn usage_from(v: &serde_json::Value) -> Usage {
@@ -125,4 +206,23 @@ fn usage_from(v: &serde_json::Value) -> Usage {
             .and_then(|n| n.as_u64())
             .unwrap_or(0),
     }
+}
+
+fn summarize_tool_input(input: Option<&serde_json::Value>) -> Option<String> {
+    let input = input?;
+    for key in [
+        "command",
+        "file_path",
+        "path",
+        "pattern",
+        "url",
+        "query",
+        "description",
+    ] {
+        if let Some(s) = input.get(key).and_then(|v| v.as_str()) {
+            let trimmed: String = s.chars().take(80).collect();
+            return Some(trimmed.replace('\n', " "));
+        }
+    }
+    None
 }

--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -27,8 +27,8 @@ impl Agent for Codex {
         cmd
     }
 
-    fn parse_event(&self, line: &str) -> AgentEvent {
-        parse(line).unwrap_or_else(|| AgentEvent::Other(line.to_string()))
+    fn parse_event(&self, line: &str) -> Vec<AgentEvent> {
+        parse(line).map(|e| vec![e]).unwrap_or_default()
     }
 }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,5 +1,7 @@
 use anyhow::{Result, bail};
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use crate::logger::LogSink;
 
@@ -32,10 +34,11 @@ pub async fn run(
     repo: &Path,
     prompt: &str,
     sink: &LogSink,
+    cancelled: Arc<AtomicBool>,
 ) -> Result<AgentOutcome> {
     let mut cmd = agent.build_streaming_command(prompt);
     cmd.current_dir(repo);
-    stream::run_streamed(cmd, agent, sink).await
+    stream::run_streamed(cmd, agent, sink, cancelled).await
 }
 
 pub async fn run_oneshot(agent: &dyn Agent, repo: &Path, prompt: &str) -> Result<String> {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -15,12 +15,13 @@ pub trait Agent: Send + Sync {
     fn name(&self) -> &str;
     fn build_streaming_command(&self, prompt: &str) -> tokio::process::Command;
     fn build_oneshot_command(&self, prompt: &str) -> tokio::process::Command;
-    fn parse_event(&self, line: &str) -> AgentEvent;
+    /// One stdout line may produce zero, one, or several events.
+    fn parse_event(&self, line: &str) -> Vec<AgentEvent>;
 }
 
 pub fn from_name(name: &str) -> Result<Box<dyn Agent>> {
     match name {
-        "claude" | "claude-code" => Ok(Box::new(claude_code::ClaudeCode)),
+        "claude" | "claude-code" => Ok(Box::new(claude_code::ClaudeCode::new())),
         "codex" => Ok(Box::new(codex::Codex)),
         other => bail!("unknown agent `{other}` — supported: claude, claude-code, codex"),
     }

--- a/src/agent/stream.rs
+++ b/src/agent/stream.rs
@@ -1,5 +1,8 @@
 use anyhow::{Context, Result, bail};
 use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
@@ -19,8 +22,11 @@ pub async fn run_streamed(
     mut cmd: Command,
     agent: &dyn Agent,
     sink: &LogSink,
+    cancelled: Arc<AtomicBool>,
 ) -> Result<AgentOutcome> {
-    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd.stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
     let name = agent.name().to_string();
     let mut child = cmd
         .spawn()
@@ -40,18 +46,37 @@ pub async fn run_streamed(
     let mut accumulated = String::new();
     let mut usage = Usage::default();
     let mut reader = BufReader::new(stdout).lines();
-    while let Ok(Some(line)) = reader.next_line().await {
-        for event in agent.parse_event(&line) {
-            sink.event(&line, &event);
-            match &event {
-                AgentEvent::Message(text) => {
-                    accumulated.push_str(text);
-                    accumulated.push('\n');
+    let mut interrupted = false;
+    loop {
+        if cancelled.load(Ordering::SeqCst) && !interrupted {
+            interrupted = true;
+            sink.note(&format!("interrupting {name} (Ctrl-C)"));
+            let _ = child.kill().await;
+        }
+        tokio::select! {
+            line = reader.next_line() => {
+                match line {
+                    Ok(Some(line)) => {
+                        for event in agent.parse_event(&line) {
+                            sink.event(&line, &event);
+                            match &event {
+                                AgentEvent::Message(text) => {
+                                    accumulated.push_str(text);
+                                    accumulated.push('\n');
+                                }
+                                AgentEvent::Usage(u) => {
+                                    usage = *u;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(_) => break,
                 }
-                AgentEvent::Usage(u) => {
-                    usage = *u;
-                }
-                _ => {}
+            }
+            _ = tokio::time::sleep(Duration::from_millis(200)) => {
+                // periodic poll so we notice cancellation even if the agent goes silent
             }
         }
     }
@@ -59,6 +84,9 @@ pub async fn run_streamed(
     let status = child.wait().await?;
     let _ = stderr_task.await;
 
+    if interrupted {
+        bail!("{name} cancelled");
+    }
     if !status.success() {
         bail!("{name} exited with status {status}");
     }

--- a/src/agent/stream.rs
+++ b/src/agent/stream.rs
@@ -41,17 +41,18 @@ pub async fn run_streamed(
     let mut usage = Usage::default();
     let mut reader = BufReader::new(stdout).lines();
     while let Ok(Some(line)) = reader.next_line().await {
-        let event = agent.parse_event(&line);
-        sink.event(&line, &event);
-        match &event {
-            AgentEvent::Message(text) => {
-                accumulated.push_str(text);
-                accumulated.push('\n');
+        for event in agent.parse_event(&line) {
+            sink.event(&line, &event);
+            match &event {
+                AgentEvent::Message(text) => {
+                    accumulated.push_str(text);
+                    accumulated.push('\n');
+                }
+                AgentEvent::Usage(u) => {
+                    usage = *u;
+                }
+                _ => {}
             }
-            AgentEvent::Usage(u) => {
-                usage = *u;
-            }
-            _ => {}
         }
     }
 

--- a/src/agent/stream.rs
+++ b/src/agent/stream.rs
@@ -57,8 +57,9 @@ pub async fn run_streamed(
             line = reader.next_line() => {
                 match line {
                     Ok(Some(line)) => {
+                        sink.record_raw_event(&line);
                         for event in agent.parse_event(&line) {
-                            sink.event(&line, &event);
+                            sink.event(&event);
                             match &event {
                                 AgentEvent::Message(text) => {
                                     accumulated.push_str(text);

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -104,6 +104,10 @@ pub async fn run(args: IterationArgs) -> Result<()> {
             if cancelled.load(Ordering::SeqCst) {
                 break;
             }
+            sink.note(&format!(
+                "── iteration {iteration} / {} ──",
+                args.max_iterations
+            ));
             ui::set_status(
                 &bar,
                 iteration,
@@ -121,7 +125,7 @@ pub async fn run(args: IterationArgs) -> Result<()> {
             let prompt_body = prompt::build_task_prompt(&parts, body);
             prompt::save_prompt(&run_dirs.prompts_dir, iteration, &prompt_body)?;
 
-            match agent::run(&*agent_impl, &repo, &prompt_body, &sink).await {
+            match agent::run(&*agent_impl, &repo, &prompt_body, &sink, cancelled.clone()).await {
                 Ok(out) => {
                     consecutive_failures = 0;
                     git::stage_all(&repo)?;

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use std::process::Command as StdCommand;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
 
 use crate::cli::IterationArgs;
 use crate::{
@@ -55,6 +54,7 @@ pub async fn run(args: IterationArgs) -> Result<()> {
     }
 
     let starting_branch = git::current_branch(&repo)?;
+    let _cursor = ui::CursorGuard::new();
     let bar = ui::make_status_bar();
 
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -96,7 +96,6 @@ pub async fn run(args: IterationArgs) -> Result<()> {
             body
         ));
 
-        let started = Instant::now();
         let mut consecutive_failures = 0u32;
         let mut completed = false;
 
@@ -111,7 +110,6 @@ pub async fn run(args: IterationArgs) -> Result<()> {
             ui::set_status(
                 &bar,
                 iteration,
-                started.elapsed(),
                 consecutive_failures,
                 &format!("task {}/{}", task_idx, pending.len()),
             );

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -107,8 +107,7 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                 "── iteration {iteration} / {} ──",
                 args.max_iterations
             ));
-            ui::set_status(
-                &bar,
+            sink.set_iteration_status(
                 iteration,
                 consecutive_failures,
                 &format!("task {}/{}", task_idx, pending.len()),

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -167,6 +167,12 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                     }
                 }
                 Err(e) => {
+                    if cancelled.load(Ordering::SeqCst) {
+                        // User cancellation — bail out of the
+                        // per-task loop without resetting the worktree
+                        // or counting it as a failure.
+                        break;
+                    }
                     consecutive_failures += 1;
                     sink.note(&format!("✗ failed: {e}"));
                     git::reset_hard(&repo).ok();

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use chrono::Utc;
 use serde::Serialize;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -28,6 +28,7 @@ pub struct LogSink {
     log: Arc<Mutex<File>>,
     events: Arc<Mutex<File>>,
     bar: Option<ProgressBar>,
+    color: bool,
 }
 
 impl LogSink {
@@ -41,10 +42,12 @@ impl LogSink {
             .create(true)
             .append(true)
             .open(events_path)?;
+        let color = std::io::stdout().is_terminal();
         Ok(Self {
             log: Arc::new(Mutex::new(log)),
             events: Arc::new(Mutex::new(events)),
             bar,
+            color,
         })
     }
 
@@ -80,10 +83,15 @@ impl LogSink {
     }
 
     fn print(&self, line: &str) {
-        if let Some(bar) = &self.bar {
-            bar.println(format!("│ {line}"));
+        let styled = if self.color {
+            colorize(line)
         } else {
-            println!("{line}");
+            line.to_string()
+        };
+        if let Some(bar) = &self.bar {
+            bar.println(format!("│ {styled}"));
+        } else {
+            println!("{styled}");
         }
     }
 }
@@ -110,5 +118,42 @@ fn format_event(event: &AgentEvent) -> Option<String> {
         AgentEvent::Stop { reason } => Some(format!("(stop: {reason})")),
         AgentEvent::Usage(_) => None,
         AgentEvent::Other(_) => None,
+    }
+}
+
+/// ANSI color the line based on its leading marker. Plain text falls
+/// through unchanged. The log.ndjson copy is unaffected — only the
+/// terminal-bound `print` path passes through this.
+fn colorize(line: &str) -> String {
+    if line.starts_with("═══") {
+        // major header: bold reverse cyan
+        format!("\x1b[1;7;36m {line} \x1b[0m")
+    } else if line.starts_with("──") {
+        // minor header (per-task iteration): bold cyan
+        format!("\x1b[1;36m{line}\x1b[0m")
+    } else if line.starts_with("=== task") {
+        // iteration-mode task header: bold reverse magenta
+        format!("\x1b[1;7;35m {line} \x1b[0m")
+    } else if line.starts_with("✓ committed") || line.starts_with("✓ PR") {
+        format!("\x1b[1;32m{line}\x1b[0m") // bold green
+    } else if line.starts_with("✗") {
+        format!("\x1b[31m{line}\x1b[0m") // red
+    } else if line.starts_with("▶") {
+        format!("\x1b[34m{line}\x1b[0m") // blue
+    } else if line.starts_with("✓") {
+        format!("\x1b[2;32m{line}\x1b[0m") // dim green
+    } else if line.starts_with("(stop:") {
+        format!("\x1b[2;3m{line}\x1b[0m") // dim italic
+    } else if line.starts_with("kobito ")
+        || line.starts_with("project:")
+        || line.starts_with("done")
+        || line.starts_with("  tokens —")
+        || line.starts_with("agent reported")
+        || line.starts_with("interrupting")
+        || line.starts_with("interrupted")
+    {
+        format!("\x1b[2m{line}\x1b[0m") // dim
+    } else {
+        line.to_string()
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -83,13 +83,18 @@ impl LogSink {
     }
 
     fn print(&self, line: &str) {
-        let styled = if self.color {
-            colorize(line)
+        let raw = if self.bar.is_some() {
+            format!(" │ {line}")
         } else {
             line.to_string()
         };
+        let styled = if self.color {
+            colorize(line, &raw)
+        } else {
+            raw
+        };
         if let Some(bar) = &self.bar {
-            bar.println(format!("│ {styled}"));
+            bar.println(styled);
         } else {
             println!("{styled}");
         }
@@ -123,39 +128,71 @@ fn format_event(event: &AgentEvent) -> Option<String> {
     }
 }
 
-/// ANSI color the line based on its leading marker. Plain text falls
-/// through unchanged. The log.ndjson copy is unaffected — only the
-/// terminal-bound `print` path passes through this.
-fn colorize(line: &str) -> String {
-    if line.starts_with("═══") {
-        // major header: bold reverse cyan
-        format!("\x1b[1;7;36m {line} \x1b[0m")
-    } else if line.starts_with("──") {
-        // minor header (per-task iteration): bold cyan
-        format!("\x1b[1;36m{line}\x1b[0m")
-    } else if line.starts_with("=== task") {
-        // iteration-mode task header: bold reverse magenta
-        format!("\x1b[1;7;35m {line} \x1b[0m")
-    } else if line.starts_with("✓ committed") || line.starts_with("✓ PR") {
-        format!("\x1b[1;32m{line}\x1b[0m") // bold green
-    } else if line.starts_with("✗") {
-        format!("\x1b[31m{line}\x1b[0m") // red
-    } else if line.starts_with("▶") {
-        format!("\x1b[34m{line}\x1b[0m") // blue
-    } else if line.starts_with("✓") {
-        format!("\x1b[2;32m{line}\x1b[0m") // dim green
-    } else if line.starts_with("(stop:") {
-        format!("\x1b[2;3m{line}\x1b[0m") // dim italic
-    } else if line.starts_with("kobito ")
+/// Muted dark theme using 24-bit color.
+///
+/// Two near-grey backgrounds split the stream:
+///
+/// - **kobito channel** (#191e2a, slightly cool slate) — everything
+///   kobito itself emits: start banner, iteration / task boundaries,
+///   commit landed, tokens / summary, sentinel notices.
+/// - **agent stream** (#121316, near-black) — the agent's own
+///   message text and tool calls.
+///
+/// Within each channel only the foreground tone changes — no extra
+/// hues. A muted maroon (#32161a) is the lone exception, reserved
+/// for failures and cancellation.
+///
+/// Routed only through the terminal `print` path; `log.ndjson` and
+/// `events.ndjson` get the plain string.
+fn colorize(judge: &str, full: &str) -> String {
+    let (bg, fg, bold) = section_for(judge);
+    let mut codes = bg.to_string();
+    if let Some(fg) = fg {
+        codes.push(';');
+        codes.push_str(fg);
+    }
+    if bold {
+        codes.push_str(";1");
+    }
+    format!("\x1b[{codes}m{full}\x1b[K\x1b[0m")
+}
+
+fn section_for(line: &str) -> (&'static str, Option<&'static str>, bool) {
+    // 24-bit truecolor: 48;2;<r>;<g>;<b> for BG, 38;2;... for FG.
+    // Two BGs + one accent BG. Three FG tones.
+    const KOBITO_BG: &str = "48;2;25;30;42"; // cool slate
+    const KOBITO_FG_BRIGHT: &str = "38;2;180;200;225";
+    const KOBITO_FG_MID: &str = "38;2;130;150;180";
+    const BODY_BG: &str = "48;2;18;19;22"; // near-black
+    const BODY_FG_DIM: &str = "38;2;90;95;105";
+    const ERROR_BG: &str = "48;2;50;22;26"; // muted maroon
+    const ERROR_FG: &str = "38;2;200;165;170";
+
+    if line.starts_with("kobito start")
+        || line.starts_with("kobito resume")
         || line.starts_with("project:")
-        || line.starts_with("done")
+        || line.starts_with("═══")
+        || line.starts_with("──")
+        || line.starts_with("=== task")
+        || line.starts_with("✓ committed")
+        || line.starts_with("✓ PR")
+    {
+        // major header — kobito BG, bright FG, bold
+        (KOBITO_BG, Some(KOBITO_FG_BRIGHT), true)
+    } else if line.starts_with("done ")
         || line.starts_with("  tokens —")
         || line.starts_with("agent reported")
-        || line.starts_with("interrupting")
-        || line.starts_with("interrupted")
     {
-        format!("\x1b[2m{line}\x1b[0m") // dim
+        // summary / tokens / sentinel — kobito BG, mid FG
+        (KOBITO_BG, Some(KOBITO_FG_MID), false)
+    } else if line.starts_with("✗") || line.starts_with("interrupting") {
+        // error / cancellation — muted maroon
+        (ERROR_BG, Some(ERROR_FG), true)
+    } else if line.starts_with("▶") {
+        // tool call — body BG, dim FG
+        (BODY_BG, Some(BODY_FG_DIM), false)
     } else {
-        line.to_string()
+        // agent body — body BG only, terminal default FG
+        (BODY_BG, None, false)
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -110,11 +110,13 @@ fn format_event(event: &AgentEvent) -> Option<String> {
             Some(s) => format!("▶ {tool}: {s}"),
             None => format!("▶ {tool}"),
         }),
-        AgentEvent::ToolEnd { tool, ok } => Some(if *ok {
-            format!("✓ {tool}")
-        } else {
-            format!("✗ {tool}")
-        }),
+        AgentEvent::ToolEnd { tool, ok } => {
+            if *ok {
+                None
+            } else {
+                Some(format!("✗ {tool}"))
+            }
+        }
         AgentEvent::Stop { reason } => Some(format!("(stop: {reason})")),
         AgentEvent::Usage(_) => None,
         AgentEvent::Other(_) => None,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -75,7 +75,7 @@ impl LogSink {
             let _ = writeln!(f, "{json}");
         }
         if let Some(formatted) = format_event(event) {
-            self.print(&formatted);
+            self.write("agent", &formatted);
         }
     }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use indicatif::ProgressBar;
 
-use crate::agent::AgentEvent;
+use crate::agent::{AgentEvent, Usage};
 
 #[derive(Serialize)]
 struct LogLine<'a> {
@@ -29,6 +29,14 @@ pub struct LogSink {
     events: Arc<Mutex<File>>,
     bar: Option<ProgressBar>,
     color: bool,
+    state: Arc<Mutex<StatusState>>,
+}
+
+#[derive(Default, Clone)]
+struct StatusState {
+    retries: u32,
+    state_label: String,
+    usage: Usage,
 }
 
 impl LogSink {
@@ -48,7 +56,37 @@ impl LogSink {
             events: Arc::new(Mutex::new(events)),
             bar,
             color,
+            state: Arc::new(Mutex::new(StatusState::default())),
         })
+    }
+
+    /// Update the iteration / retry / state label and refresh the bar.
+    /// Token usage is tracked separately and updated whenever a
+    /// Usage event arrives.
+    pub fn set_iteration_status(&self, iteration: u32, retries: u32, state_label: &str) {
+        if let Some(bar) = &self.bar {
+            bar.set_prefix(iteration.to_string());
+        }
+        if let Ok(mut s) = self.state.lock() {
+            s.retries = retries;
+            s.state_label = state_label.to_string();
+        }
+        self.refresh_bar();
+    }
+
+    fn refresh_bar(&self) {
+        let Some(bar) = &self.bar else { return };
+        let s = match self.state.lock() {
+            Ok(g) => g.clone(),
+            Err(_) => return,
+        };
+        bar.set_message(format!(
+            "in {}  ·  out {}  ·  retry {}  ·  {}",
+            format_count(s.usage.input_tokens),
+            format_count(s.usage.output_tokens),
+            s.retries,
+            s.state_label,
+        ));
     }
 
     pub fn write(&self, source: &str, line: &str) {
@@ -77,6 +115,12 @@ impl LogSink {
         {
             let _ = writeln!(f, "{json}");
         }
+        if let AgentEvent::Usage(u) = event {
+            if let Ok(mut s) = self.state.lock() {
+                s.usage = *u;
+            }
+            self.refresh_bar();
+        }
         if let Some(formatted) = format_event(event) {
             self.write("agent", &formatted);
         }
@@ -98,6 +142,16 @@ impl LogSink {
         } else {
             println!("{styled}");
         }
+    }
+}
+
+fn format_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
     }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -107,7 +107,8 @@ impl LogSink {
         self.write("kobito", line);
     }
 
-    pub fn event(&self, raw: &str, event: &AgentEvent) {
+    /// Persist one raw stdout line to events.ndjson.
+    pub fn record_raw_event(&self, raw: &str) {
         if let Ok(json) = serde_json::to_string(&EventLine {
             ts: Utc::now().to_rfc3339(),
             raw,
@@ -115,6 +116,11 @@ impl LogSink {
         {
             let _ = writeln!(f, "{json}");
         }
+    }
+
+    /// Render one parsed event to the terminal + log.ndjson and
+    /// update the in-memory status state.
+    pub fn event(&self, event: &AgentEvent) {
         if let AgentEvent::Usage(u) = event {
             if let Ok(mut s) = self.state.lock() {
                 s.usage = *u;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,7 +6,6 @@ use std::io::IsTerminal;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
 
 use crate::agent::Agent;
 use crate::cli::{ContinuousArgs, ResumeArgs};
@@ -57,6 +56,7 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
         },
     )?;
 
+    let _cursor = ui::CursorGuard::new();
     let bar = ui::make_status_bar();
     let sink = LogSink::open(&run.log_file, Some(bar.clone()))?;
     let cancelled = install_cancel_handler();
@@ -124,6 +124,7 @@ pub async fn resume_continuous(args: ResumeArgs) -> Result<()> {
         },
     )?;
 
+    let _cursor = ui::CursorGuard::new();
     let bar = ui::make_status_bar();
     let sink = LogSink::open(&new_run.log_file, Some(bar.clone()))?;
     let cancelled = install_cancel_handler();
@@ -174,7 +175,6 @@ struct LoopArgs<'a> {
 }
 
 async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
-    let started = Instant::now();
     let mut consecutive_failures = 0u32;
     let mut total_retries = 0u32;
     let mut completed = 0u32;
@@ -188,13 +188,7 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
             "═══ iteration {iteration} / {} ═══",
             args.max_iterations
         ));
-        ui::set_status(
-            args.bar,
-            iteration,
-            started.elapsed(),
-            total_retries,
-            "thinking",
-        );
+        ui::set_status(args.bar, iteration, total_retries, "thinking");
 
         let notes = fs::read_to_string(state::notes_path(args.run)).ok();
         let parts = prompt::PromptParts {
@@ -228,13 +222,7 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
                         .note("iteration produced no diff — skipping commit");
                     continue;
                 }
-                ui::set_status(
-                    args.bar,
-                    iteration,
-                    started.elapsed(),
-                    total_retries,
-                    "committing",
-                );
+                ui::set_status(args.bar, iteration, total_retries, "committing");
                 let diff = git::diff_staged(args.repo)?;
                 let style = git::recent_commit_messages(args.repo, 20).unwrap_or_default();
                 let msg = commit::generate_message(args.agent, args.repo, &diff, args.goal, &style)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,5 @@
 use anyhow::{Result, anyhow, bail};
 use chrono::Utc;
-use indicatif::ProgressBar;
 use std::fs;
 use std::io::IsTerminal;
 use std::path::Path;
@@ -76,7 +75,6 @@ pub async fn run_continuous(args: ContinuousArgs) -> Result<()> {
         max_iterations: args.max_iterations,
         max_failures: args.max_failures,
         sink: &sink,
-        bar: &bar,
         cancelled,
     })
     .await?;
@@ -147,7 +145,6 @@ pub async fn resume_continuous(args: ResumeArgs) -> Result<()> {
         max_iterations: args.max_iterations,
         max_failures: args.max_failures,
         sink: &sink,
-        bar: &bar,
         cancelled,
     })
     .await?;
@@ -170,7 +167,6 @@ struct LoopArgs<'a> {
     max_iterations: u32,
     max_failures: u32,
     sink: &'a LogSink,
-    bar: &'a ProgressBar,
     cancelled: Arc<AtomicBool>,
 }
 
@@ -188,7 +184,8 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
             "═══ iteration {iteration} / {} ═══",
             args.max_iterations
         ));
-        ui::set_status(args.bar, iteration, total_retries, "thinking");
+        args.sink
+            .set_iteration_status(iteration, total_retries, "thinking");
 
         let notes = fs::read_to_string(state::notes_path(args.run)).ok();
         let parts = prompt::PromptParts {
@@ -222,7 +219,8 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
                         .note("iteration produced no diff — skipping commit");
                     continue;
                 }
-                ui::set_status(args.bar, iteration, total_retries, "committing");
+                args.sink
+                    .set_iteration_status(iteration, total_retries, "committing");
                 let diff = git::diff_staged(args.repo)?;
                 let style = git::recent_commit_messages(args.repo, 20).unwrap_or_default();
                 let msg = commit::generate_message(args.agent, args.repo, &diff, args.goal, &style)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -184,6 +184,10 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
             args.sink.note("interrupted by user");
             break;
         }
+        args.sink.note(&format!(
+            "═══ iteration {iteration} / {} ═══",
+            args.max_iterations
+        ));
         ui::set_status(
             args.bar,
             iteration,
@@ -202,7 +206,15 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
         let body = prompt::build_iteration_prompt(&parts);
         prompt::save_prompt(&args.run.prompts_dir, iteration, &body)?;
 
-        match agent::run(args.agent, args.repo, &body, args.sink).await {
+        match agent::run(
+            args.agent,
+            args.repo,
+            &body,
+            args.sink,
+            args.cancelled.clone(),
+        )
+        .await
+        {
             Ok(out) => {
                 consecutive_failures = 0;
                 if out.natural_stop {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -247,6 +247,12 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
                 }
             }
             Err(e) => {
+                if args.cancelled.load(Ordering::SeqCst) {
+                    // User cancellation — leave the working tree
+                    // alone and exit the loop, don't count it as a
+                    // failure or burn a retry / backoff.
+                    break;
+                }
                 consecutive_failures += 1;
                 total_retries += 1;
                 args.sink.note(&format!("✗ iteration failed: {e}"));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -59,8 +59,3 @@ pub fn make_status_bar() -> ProgressBar {
     bar.enable_steady_tick(Duration::from_millis(120));
     bar
 }
-
-pub fn set_status(bar: &ProgressBar, iteration: u32, retries: u32, state: &str) {
-    bar.set_prefix(iteration.to_string());
-    bar.set_message(format!("retry {retries}  ·  {state}"));
-}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,52 @@
 use indicatif::{ProgressBar, ProgressStyle};
+use std::io::Write;
 use std::time::Duration;
+
+/// Hides the terminal cursor for the duration of its scope.
+///
+/// Indicatif's spinner already paints over the cursor most of the time,
+/// but the cursor flashes through between bar redraws. Hide it on
+/// construction, restore it on drop — works for normal exits, panics,
+/// and the explicit drop in the Ctrl-C handler.
+pub struct CursorGuard;
+
+impl CursorGuard {
+    pub fn new() -> Self {
+        print!("\x1b[?25l");
+        let _ = std::io::stdout().flush();
+        Self
+    }
+}
+
+impl Drop for CursorGuard {
+    fn drop(&mut self) {
+        print!("\x1b[?25h");
+        let _ = std::io::stdout().flush();
+    }
+}
 
 pub fn make_status_bar() -> ProgressBar {
     let bar = ProgressBar::new_spinner();
+    // Two-line template:
+    //   1. a thin separator rule, dimmed
+    //   2. the actual status row, painted on the kobito-channel BG
+    //      to end-of-line via \x1b[K so the bar reads as a sticky
+    //      footer rather than a floating spinner.
+    //
+    // {elapsed_precise} is owned by indicatif so the seconds tick on
+    // every steady_tick (every 120 ms below) without us re-calling
+    // set_message.
+    let rule = "\x1b[38;2;90;95;105m\
+        ──────────────────────────────────────────────────────────────────\
+        \x1b[0m";
+    let template = format!(
+        "{rule}\n\
+         \x1b[48;2;25;30;42m\x1b[38;2;180;200;225m \
+         {{spinner}}  iter {{prefix}}  ·  {{elapsed_precise}}  ·  {{msg}} \
+         \x1b[K\x1b[0m",
+    );
     bar.set_style(
-        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+        ProgressStyle::with_template(&template)
             .unwrap()
             .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ "),
     );
@@ -12,12 +54,7 @@ pub fn make_status_bar() -> ProgressBar {
     bar
 }
 
-pub fn set_status(bar: &ProgressBar, iteration: u32, elapsed: Duration, retries: u32, state: &str) {
-    let secs = elapsed.as_secs();
-    let h = secs / 3600;
-    let m = (secs % 3600) / 60;
-    let s = secs % 60;
-    bar.set_message(format!(
-        "iter {iteration} · {h:02}:{m:02}:{s:02} · retry {retries} · {state}"
-    ));
+pub fn set_status(bar: &ProgressBar, iteration: u32, retries: u32, state: &str) {
+    bar.set_prefix(iteration.to_string());
+    bar.set_message(format!("retry {retries}  ·  {state}"));
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -48,7 +48,8 @@ pub fn make_status_bar() -> ProgressBar {
         "\x1b[48;2;25;30;42m\x1b[38;2;90;95;105m{rule}\x1b[0m\n\
          \x1b[48;2;25;30;42m\x1b[38;2;180;200;225m \
          {{spinner}}  iter {{prefix}}  ·  {{elapsed_precise}}  ·  {{wide_msg}}\
-         \x1b[0m"
+         \x1b[0m\n\
+         \x1b[48;2;25;30;42m\x1b[38;2;90;95;105m{rule}\x1b[0m"
     );
     bar.set_style(
         ProgressStyle::with_template(&template)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,4 @@
+use console::Term;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::io::Write;
 use std::time::Duration;
@@ -28,22 +29,26 @@ impl Drop for CursorGuard {
 pub fn make_status_bar() -> ProgressBar {
     let bar = ProgressBar::new_spinner();
     // Two-line template:
-    //   1. a thin separator rule, dimmed
-    //   2. the actual status row, painted on the kobito-channel BG
-    //      to end-of-line via \x1b[K so the bar reads as a sticky
-    //      footer rather than a floating spinner.
+    //   1. a separator rule painted across the full terminal width on
+    //      the kobito-channel BG so the rule itself is part of the
+    //      footer block, not a free-floating line of dashes.
+    //   2. the status row, also on the kobito BG. {wide_msg} fills
+    //      whatever horizontal space is left so the BG continues to
+    //      end-of-line regardless of terminal width.
     //
     // {elapsed_precise} is owned by indicatif so the seconds tick on
     // every steady_tick (every 120 ms below) without us re-calling
     // set_message.
-    let rule = "\x1b[38;2;90;95;105m\
-        ──────────────────────────────────────────────────────────────────\
-        \x1b[0m";
+    let width = Term::stdout()
+        .size_checked()
+        .map(|(_, w)| w as usize)
+        .unwrap_or(80);
+    let rule = "─".repeat(width);
     let template = format!(
-        "{rule}\n\
+        "\x1b[48;2;25;30;42m\x1b[38;2;90;95;105m{rule}\x1b[0m\n\
          \x1b[48;2;25;30;42m\x1b[38;2;180;200;225m \
-         {{spinner}}  iter {{prefix}}  ·  {{elapsed_precise}}  ·  {{msg}} \
-         \x1b[K\x1b[0m",
+         {{spinner}}  iter {{prefix}}  ·  {{elapsed_precise}}  ·  {{wide_msg}}\
+         \x1b[0m"
     );
     bar.set_style(
         ProgressStyle::with_template(&template)


### PR DESCRIPTION
## Summary

Follow-ups to PR #26 — that PR landed the structured-streaming pipeline but the live feed in the terminal was still mostly broken. This PR makes it actually useful.

## What's in here

| # | commit | what it fixes |
|---|---|---|
| 1 | fix(agent): unwrap stream_event envelope and write event lines to log.ndjson | Claude Code wraps Messages-API events under `{"type":"stream_event","event":{...}}` / `{"type":"assistant",...}` / `{"type":"user",...}` / `{"type":"result",...}`. The previous parser matched only the outer `type` and silently fell through to `Other`, so the terminal stayed empty. Also: `LogSink::event` now writes the formatted line to `log.ndjson` instead of going straight to the terminal. |
| 2 | fix(agent): show tool names + summaries, capture final token usage | Without `--include-partial-messages`, Claude Code only emits envelope events. Pull `tool_use` out of `assistant.message.content[]`, remember its id, and resolve `tool_result.tool_use_id` back to the original tool name on the way out — no more rows of `✓ tool`. Tool starts now carry a 1-line summary derived from `command` / `file_path` / `pattern` / `url` / `query`. Final cumulative token usage is read from the `result` event. `parse_event` becomes `Vec<AgentEvent>` so a single envelope can yield several events. |
| 3 | feat(ui): colorise output, mark iteration boundaries, and forward Ctrl-C to the agent | Iteration & task headers (`═══ iteration N / 50 ═══` / `── iteration N / 30 ──` / `=== task N/M: … ===`) cut the stream into scannable chunks. Ctrl-C is now forwarded to the running `claude` / `codex` child via `child.kill()` inside a `tokio::select!` poll, so cancellation is felt within ~200 ms instead of after the agent finishes its turn. |
| 4 | feat(ui): silence successful tool ends | `▶ Bash: cargo test` followed by `✓ Bash` was pure noise — success is the assumed case and the `▶` line already announced the call. Drop `ToolEnd { ok: true }` from the terminal feed; failures still surface as `✗ tool` in red. |
| 5 | feat(ui): muted slate palette with section accents | Final colour theme: kobito-emitted lines on a cool slate BG (rgb 25,30,42), agent body on near-black slate (rgb 18,19,22), failures the lone non-grey accent (rgb 50,22,26). Three FG tones separate weight; backgrounds painted to end-of-line via `\x1b[K` so the kobito column is visually distinct. |

## Test plan

- [ ] `cargo test --bin kobito` — 18 tests green
- [ ] `cargo build --release`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `kobito cont --preset coverage` on a sample repo: the live feed shows iteration headers, ▶ tool calls with summaries, agent message text, ✓ committed lines, and final tokens line — all colour-coded
- [ ] Ctrl-C mid-iteration kills the agent within ~200 ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cancellation responsiveness: system now detects interruption (Ctrl-C) even during idle periods and terminates gracefully.
  * Terminal-aware ANSI color styling for enhanced visual feedback in terminal output.

* **Bug Fixes**
  * Cleaner log output: successful tool executions no longer displayed, only failures.
  * Better progress indicators with improved formatting and gutter alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->