### PR TITLE
test: raise unit-test coverage across core modules

### DIFF
--- a/src/agent/claude_code.rs
+++ b/src/agent/claude_code.rs
@@ -300,7 +300,8 @@ mod tests {
     #[test]
     fn assistant_text_emits_message_event() {
         let agent = ClaudeCode::new();
-        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi there"}]}}"#;
+        let line =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi there"}]}}"#;
         let evs = parse_one(&agent, line);
         assert_eq!(evs.len(), 1);
         match &evs[0] {
@@ -358,8 +359,7 @@ mod tests {
     #[test]
     fn assistant_skips_unknown_content_item_types() {
         let agent = ClaudeCode::new();
-        let line =
-            r#"{"type":"assistant","message":{"content":[{"type":"image","data":"abc"}]}}"#;
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"image","data":"abc"}]}}"#;
         assert!(parse_one(&agent, line).is_empty());
     }
 
@@ -375,7 +375,8 @@ mod tests {
         let agent = ClaudeCode::new();
         let start = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"abc","name":"Read","input":{"file_path":"/etc/hosts"}}]}}"#;
         let _ = parse_one(&agent, start);
-        let end = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"abc"}]}}"#;
+        let end =
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"abc"}]}}"#;
         let evs = parse_one(&agent, end);
         match &evs[0] {
             AgentEvent::ToolEnd { tool, ok } => {
@@ -498,8 +499,7 @@ mod tests {
     #[test]
     fn stream_event_message_start_without_usage_returns_empty() {
         let agent = ClaudeCode::new();
-        let line =
-            r#"{"type":"stream_event","event":{"type":"message_start","message":{}}}"#;
+        let line = r#"{"type":"stream_event","event":{"type":"message_start","message":{}}}"#;
         assert!(parse_one(&agent, line).is_empty());
     }
 

--- a/src/agent/claude_code.rs
+++ b/src/agent/claude_code.rs
@@ -229,3 +229,302 @@ fn summarize_tool_input(input: Option<&serde_json::Value>) -> Option<String> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_one(agent: &ClaudeCode, line: &str) -> Vec<AgentEvent> {
+        agent.parse_event(line)
+    }
+
+    #[test]
+    fn name_returns_claude() {
+        assert_eq!(ClaudeCode::new().name(), "claude");
+    }
+
+    #[test]
+    fn streaming_command_uses_stream_json_with_bypass() {
+        let agent = ClaudeCode::new();
+        let cmd = agent.build_streaming_command("hi");
+        let std_cmd = cmd.as_std();
+        assert_eq!(std_cmd.get_program(), "claude");
+        let args: Vec<&str> = std_cmd.get_args().filter_map(|a| a.to_str()).collect();
+        assert_eq!(
+            args,
+            vec![
+                "-p",
+                "hi",
+                "--permission-mode",
+                "bypassPermissions",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+            ]
+        );
+    }
+
+    #[test]
+    fn oneshot_command_uses_text_output() {
+        let agent = ClaudeCode::new();
+        let cmd = agent.build_oneshot_command("hello");
+        let std_cmd = cmd.as_std();
+        assert_eq!(std_cmd.get_program(), "claude");
+        let args: Vec<&str> = std_cmd.get_args().filter_map(|a| a.to_str()).collect();
+        assert_eq!(args, vec!["-p", "hello", "--output-format", "text"]);
+    }
+
+    #[test]
+    fn parse_event_returns_other_for_invalid_json() {
+        let agent = ClaudeCode::new();
+        let evs = parse_one(&agent, "not json");
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            AgentEvent::Other(s) => assert_eq!(s, "not json"),
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_event_returns_empty_when_type_missing() {
+        let agent = ClaudeCode::new();
+        assert!(parse_one(&agent, r#"{"foo":1}"#).is_empty());
+    }
+
+    #[test]
+    fn parse_event_returns_empty_for_unknown_kind() {
+        let agent = ClaudeCode::new();
+        assert!(parse_one(&agent, r#"{"type":"mystery"}"#).is_empty());
+    }
+
+    #[test]
+    fn assistant_text_emits_message_event() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi there"}]}}"#;
+        let evs = parse_one(&agent, line);
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            AgentEvent::Message(m) => assert_eq!(m, "hi there"),
+            other => panic!("expected Message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_blank_text_is_skipped() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"   "}]}}"#;
+        assert!(parse_one(&agent, line).is_empty());
+    }
+
+    #[test]
+    fn assistant_tool_use_emits_tool_start_with_summary() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls -al"}}]}}"#;
+        let evs = parse_one(&agent, line);
+        match &evs[0] {
+            AgentEvent::ToolStart { tool, summary } => {
+                assert_eq!(tool, "Bash");
+                assert_eq!(summary.as_deref(), Some("ls -al"));
+            }
+            other => panic!("expected ToolStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_tool_use_without_input_has_no_summary() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Read"}]}}"#;
+        let evs = parse_one(&agent, line);
+        match &evs[0] {
+            AgentEvent::ToolStart { tool, summary } => {
+                assert_eq!(tool, "Read");
+                assert!(summary.is_none());
+            }
+            other => panic!("expected ToolStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_tool_use_missing_name_falls_back_to_unknown() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"x"}]}}"#;
+        let evs = parse_one(&agent, line);
+        match &evs[0] {
+            AgentEvent::ToolStart { tool, .. } => assert_eq!(tool, "unknown"),
+            other => panic!("expected ToolStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_skips_unknown_content_item_types() {
+        let agent = ClaudeCode::new();
+        let line =
+            r#"{"type":"assistant","message":{"content":[{"type":"image","data":"abc"}]}}"#;
+        assert!(parse_one(&agent, line).is_empty());
+    }
+
+    #[test]
+    fn assistant_returns_empty_when_content_missing() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"assistant","message":{}}"#;
+        assert!(parse_one(&agent, line).is_empty());
+    }
+
+    #[test]
+    fn user_tool_result_resolves_remembered_tool_name() {
+        let agent = ClaudeCode::new();
+        let start = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"abc","name":"Read","input":{"file_path":"/etc/hosts"}}]}}"#;
+        let _ = parse_one(&agent, start);
+        let end = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"abc"}]}}"#;
+        let evs = parse_one(&agent, end);
+        match &evs[0] {
+            AgentEvent::ToolEnd { tool, ok } => {
+                assert_eq!(tool, "Read");
+                assert!(*ok);
+            }
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_tool_result_marks_error_when_is_error_true() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"unknown","is_error":true}]}}"#;
+        let evs = parse_one(&agent, line);
+        match &evs[0] {
+            AgentEvent::ToolEnd { tool, ok } => {
+                assert_eq!(tool, "tool");
+                assert!(!ok);
+            }
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_tool_result_id_is_consumed_on_resolve() {
+        let agent = ClaudeCode::new();
+        let start = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"once","name":"Grep"}]}}"#;
+        let _ = parse_one(&agent, start);
+        let end = r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"once"}]}}"#;
+        let _ = parse_one(&agent, end);
+        let again = parse_one(&agent, end);
+        match &again[0] {
+            AgentEvent::ToolEnd { tool, .. } => assert_eq!(tool, "tool"),
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_returns_empty_when_content_missing() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"user","message":{}}"#;
+        assert!(parse_one(&agent, line).is_empty());
+    }
+
+    #[test]
+    fn user_skips_non_tool_result_items() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}"#;
+        assert!(parse_one(&agent, line).is_empty());
+    }
+
+    #[test]
+    fn result_emits_usage_then_stop() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"result","subtype":"success","usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":3}}"#;
+        let evs = parse_one(&agent, line);
+        assert_eq!(evs.len(), 2);
+        match &evs[0] {
+            AgentEvent::Usage(u) => {
+                assert_eq!(u.input_tokens, 10);
+                assert_eq!(u.output_tokens, 20);
+                assert_eq!(u.cached_input_tokens, 3);
+            }
+            other => panic!("expected Usage, got {other:?}"),
+        }
+        match &evs[1] {
+            AgentEvent::Stop { reason } => assert_eq!(reason, "success"),
+            other => panic!("expected Stop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn result_without_usage_emits_only_stop_with_default_reason() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"result"}"#;
+        let evs = parse_one(&agent, line);
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            AgentEvent::Stop { reason } => assert_eq!(reason, "end"),
+            other => panic!("expected Stop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_event_message_start_emits_usage_from_message() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"stream_event","event":{"type":"message_start","message":{"usage":{"input_tokens":7}}}}"#;
+        let evs = parse_one(&agent, line);
+        match &evs[0] {
+            AgentEvent::Usage(u) => assert_eq!(u.input_tokens, 7),
+            other => panic!("expected Usage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_event_message_delta_emits_usage_directly() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"stream_event","event":{"type":"message_delta","usage":{"output_tokens":42}}}"#;
+        let evs = parse_one(&agent, line);
+        match &evs[0] {
+            AgentEvent::Usage(u) => assert_eq!(u.output_tokens, 42),
+            other => panic!("expected Usage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_event_unknown_subtype_returns_empty() {
+        let agent = ClaudeCode::new();
+        let line = r#"{"type":"stream_event","event":{"type":"content_block_stop"}}"#;
+        assert!(parse_one(&agent, line).is_empty());
+    }
+
+    #[test]
+    fn stream_event_without_inner_event_returns_empty() {
+        let agent = ClaudeCode::new();
+        assert!(parse_one(&agent, r#"{"type":"stream_event"}"#).is_empty());
+    }
+
+    #[test]
+    fn stream_event_message_start_without_usage_returns_empty() {
+        let agent = ClaudeCode::new();
+        let line =
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{}}}"#;
+        assert!(parse_one(&agent, line).is_empty());
+    }
+
+    #[test]
+    fn summarize_tool_input_picks_first_known_key_and_replaces_newlines() {
+        let v = serde_json::json!({"file_path": "a\nb"});
+        assert_eq!(summarize_tool_input(Some(&v)).as_deref(), Some("a b"));
+    }
+
+    #[test]
+    fn summarize_tool_input_truncates_to_80_chars() {
+        let long = "x".repeat(200);
+        let v = serde_json::json!({"command": long});
+        let summary = summarize_tool_input(Some(&v)).expect("should produce summary");
+        assert_eq!(summary.chars().count(), 80);
+    }
+
+    #[test]
+    fn summarize_tool_input_returns_none_for_missing_input() {
+        assert!(summarize_tool_input(None).is_none());
+    }
+
+    #[test]
+    fn summarize_tool_input_returns_none_when_no_known_key_present() {
+        let v = serde_json::json!({"unrelated": "value"});
+        assert!(summarize_tool_input(Some(&v)).is_none());
+    }
+}

--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -113,3 +113,194 @@ fn parse(line: &str) -> Option<AgentEvent> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_one(line: &str) -> Vec<AgentEvent> {
+        Codex.parse_event(line)
+    }
+
+    #[test]
+    fn name_returns_codex() {
+        assert_eq!(Codex.name(), "codex");
+    }
+
+    #[test]
+    fn streaming_command_uses_codex_exec_json() {
+        let cmd = Codex.build_streaming_command("hi");
+        let std_cmd = cmd.as_std();
+        assert_eq!(std_cmd.get_program(), "codex");
+        let args: Vec<&str> = std_cmd.get_args().filter_map(|a| a.to_str()).collect();
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--json",
+                "hi"
+            ]
+        );
+    }
+
+    #[test]
+    fn oneshot_command_uses_codex_exec_text() {
+        let cmd = Codex.build_oneshot_command("hello");
+        let std_cmd = cmd.as_std();
+        assert_eq!(std_cmd.get_program(), "codex");
+        let args: Vec<&str> = std_cmd.get_args().filter_map(|a| a.to_str()).collect();
+        assert_eq!(args, vec!["exec", "--color", "never", "hello"]);
+    }
+
+    #[test]
+    fn parse_event_returns_empty_for_invalid_json() {
+        assert!(parse_one("not json").is_empty());
+    }
+
+    #[test]
+    fn parse_event_returns_empty_when_type_field_missing() {
+        assert!(parse_one("{\"foo\":1}").is_empty());
+    }
+
+    #[test]
+    fn parse_event_returns_empty_for_unknown_type() {
+        assert!(parse_one("{\"type\":\"some.other\"}").is_empty());
+    }
+
+    #[test]
+    fn item_completed_agent_message_emits_message() {
+        let line =
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"hello there"}}"#;
+        let evs = parse_one(line);
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            AgentEvent::Message(m) => assert_eq!(m, "hello there"),
+            other => panic!("expected Message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_completed_agent_message_without_text_returns_empty() {
+        let line = r#"{"type":"item.completed","item":{"type":"agent_message"}}"#;
+        assert!(parse_one(line).is_empty());
+    }
+
+    #[test]
+    fn item_completed_command_execution_emits_tool_end_ok_when_exit_zero() {
+        let line = r#"{"type":"item.completed","item":{"type":"command_execution","command":"ls -al","exit_code":0}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::ToolEnd { tool, ok } => {
+                assert!(tool.starts_with("ls -al"));
+                assert!(*ok);
+            }
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_completed_command_execution_marks_failure_on_nonzero_exit() {
+        let line = r#"{"type":"item.completed","item":{"type":"command_execution","command":"false","exit_code":1}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::ToolEnd { ok, .. } => assert!(!ok),
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_completed_tool_call_defaults_ok_true_when_exit_code_missing() {
+        let line = r#"{"type":"item.completed","item":{"type":"tool_call","name":"shell"}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::ToolEnd { tool, ok } => {
+                assert_eq!(tool, "shell");
+                assert!(*ok);
+            }
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_completed_function_call_falls_back_to_item_type_for_tool_label() {
+        let line = r#"{"type":"item.completed","item":{"type":"function_call"}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::ToolEnd { tool, .. } => assert_eq!(tool, "function_call"),
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_completed_unknown_item_type_returns_empty() {
+        let line = r#"{"type":"item.completed","item":{"type":"weird"}}"#;
+        assert!(parse_one(line).is_empty());
+    }
+
+    #[test]
+    fn item_started_command_execution_emits_tool_start_with_summary() {
+        let line = r#"{"type":"item.started","item":{"type":"command_execution","name":"shell","command":"echo hi"}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::ToolStart { tool, summary } => {
+                assert_eq!(tool, "shell");
+                assert_eq!(summary.as_deref(), Some("echo hi"));
+            }
+            other => panic!("expected ToolStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_started_tool_call_falls_back_to_command_when_no_name() {
+        let line = r#"{"type":"item.started","item":{"type":"tool_call","command":"cat README"}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::ToolStart { tool, summary } => {
+                assert_eq!(tool, "cat README");
+                assert_eq!(summary.as_deref(), Some("cat README"));
+            }
+            other => panic!("expected ToolStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_started_for_non_tool_item_returns_empty() {
+        let line = r#"{"type":"item.started","item":{"type":"agent_message"}}"#;
+        assert!(parse_one(line).is_empty());
+    }
+
+    #[test]
+    fn turn_completed_emits_usage_with_all_fields() {
+        let line = r#"{"type":"turn.completed","usage":{"input_tokens":12,"output_tokens":34,"cached_input_tokens":5}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::Usage(u) => {
+                assert_eq!(u.input_tokens, 12);
+                assert_eq!(u.output_tokens, 34);
+                assert_eq!(u.cached_input_tokens, 5);
+            }
+            other => panic!("expected Usage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn turn_completed_defaults_missing_usage_fields_to_zero() {
+        let line = r#"{"type":"turn.completed","usage":{}}"#;
+        let evs = parse_one(line);
+        match &evs[0] {
+            AgentEvent::Usage(u) => {
+                assert_eq!(u.input_tokens, 0);
+                assert_eq!(u.output_tokens, 0);
+                assert_eq!(u.cached_input_tokens, 0);
+            }
+            other => panic!("expected Usage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn turn_completed_without_usage_returns_empty() {
+        let line = r#"{"type":"turn.completed"}"#;
+        assert!(parse_one(line).is_empty());
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -46,3 +46,47 @@ pub async fn run_oneshot(agent: &dyn Agent, repo: &Path, prompt: &str) -> Result
     cmd.current_dir(repo);
     stream::run_oneshot(cmd, agent.name()).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_name_returns_claude_code_for_claude_alias() {
+        let agent = from_name("claude").expect("claude alias should resolve");
+        assert_eq!(agent.name(), "claude");
+    }
+
+    #[test]
+    fn from_name_returns_claude_code_for_full_name() {
+        let agent = from_name("claude-code").expect("claude-code should resolve");
+        assert_eq!(agent.name(), "claude");
+    }
+
+    #[test]
+    fn from_name_returns_codex() {
+        let agent = from_name("codex").expect("codex should resolve");
+        assert_eq!(agent.name(), "codex");
+    }
+
+    #[test]
+    fn from_name_errors_for_unknown_agent() {
+        let err = from_name("ghost")
+            .err()
+            .expect("unknown agent should error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ghost"),
+            "error should mention the bad name: {msg}"
+        );
+        assert!(
+            msg.contains("claude") && msg.contains("codex"),
+            "error should list supported agents: {msg}",
+        );
+    }
+
+    #[test]
+    fn from_name_errors_for_empty_name() {
+        assert!(from_name("").is_err());
+    }
+}

--- a/src/agent/stream.rs
+++ b/src/agent/stream.rs
@@ -122,19 +122,27 @@ mod tests {
     use std::path::PathBuf;
     use std::process;
 
-    fn unique_tmp(prefix: &str) -> PathBuf {
+    struct TempDir(PathBuf);
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn unique_tmp(prefix: &str) -> TempDir {
         let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
         let pid = process::id();
         let mut path = std::env::temp_dir();
         path.push(format!("kobito-stream-{prefix}-{pid}-{nanos}"));
         std::fs::create_dir_all(&path).unwrap();
-        path
+        TempDir(path)
     }
 
-    fn open_sink(prefix: &str) -> LogSink {
+    fn open_sink(prefix: &str) -> (LogSink, TempDir) {
         let dir = unique_tmp(prefix);
-        let log = dir.join("log.ndjson");
-        LogSink::open(&log, None).unwrap()
+        let log = dir.0.join("log.ndjson");
+        let sink = LogSink::open(&log, None).unwrap();
+        (sink, dir)
     }
 
     struct FakeAgent;
@@ -180,7 +188,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_streamed_collects_messages_from_stdout() {
-        let sink = open_sink("ok");
+        let (sink, _dir) = open_sink("ok");
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg("printf 'hello\\nworld\\n'");
         let cancelled = Arc::new(AtomicBool::new(false));
@@ -195,7 +203,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_streamed_detects_natural_stop_and_task_complete() {
-        let sink = open_sink("stop");
+        let (sink, _dir) = open_sink("stop");
         let mut cmd = Command::new("sh");
         cmd.arg("-c")
             .arg("printf 'NATURAL_STOP\\nTASK_COMPLETE\\n'");
@@ -209,7 +217,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_streamed_errors_on_nonzero_exit() {
-        let sink = open_sink("fail");
+        let (sink, _dir) = open_sink("fail");
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg("echo bye; exit 3");
         let cancelled = Arc::new(AtomicBool::new(false));
@@ -224,7 +232,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_streamed_bails_with_cancelled_when_flag_is_set() {
-        let sink = open_sink("cancel");
+        let (sink, _dir) = open_sink("cancel");
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg("sleep 5");
         let cancelled = Arc::new(AtomicBool::new(true));
@@ -237,7 +245,7 @@ mod tests {
 
     #[tokio::test]
     async fn run_streamed_errors_when_binary_missing() {
-        let sink = open_sink("missing");
+        let (sink, _dir) = open_sink("missing");
         let cmd = Command::new("kobito-no-such-binary-xyz");
         let cancelled = Arc::new(AtomicBool::new(false));
         let err = run_streamed(cmd, &FakeAgent, &sink, cancelled)

--- a/src/agent/stream.rs
+++ b/src/agent/stream.rs
@@ -115,3 +115,135 @@ pub async fn run_oneshot(mut cmd: Command, name: &str) -> Result<String> {
     }
     Ok(String::from_utf8(out.stdout)?)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::process;
+
+    fn unique_tmp(prefix: &str) -> PathBuf {
+        let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        let pid = process::id();
+        let mut path = std::env::temp_dir();
+        path.push(format!("kobito-stream-{prefix}-{pid}-{nanos}"));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn open_sink(prefix: &str) -> LogSink {
+        let dir = unique_tmp(prefix);
+        let log = dir.join("log.ndjson");
+        LogSink::open(&log, None).unwrap()
+    }
+
+    struct FakeAgent;
+    impl Agent for FakeAgent {
+        fn name(&self) -> &str {
+            "fake"
+        }
+        fn build_streaming_command(&self, _: &str) -> Command {
+            Command::new("true")
+        }
+        fn build_oneshot_command(&self, _: &str) -> Command {
+            Command::new("true")
+        }
+        fn parse_event(&self, line: &str) -> Vec<AgentEvent> {
+            vec![AgentEvent::Message(line.to_string())]
+        }
+    }
+
+    #[tokio::test]
+    async fn run_oneshot_returns_stdout_on_success() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("printf 'branch-name'");
+        let out = run_oneshot(cmd, "fake").await.unwrap();
+        assert_eq!(out, "branch-name");
+    }
+
+    #[tokio::test]
+    async fn run_oneshot_errors_on_nonzero_exit_with_stderr() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("printf 'boom' >&2; exit 7");
+        let err = run_oneshot(cmd, "fake").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("fake"), "msg should mention agent: {msg}");
+        assert!(msg.contains("boom"), "msg should include stderr: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_oneshot_errors_when_binary_missing() {
+        let cmd = Command::new("kobito-no-such-binary-xyz");
+        let err = run_oneshot(cmd, "ghost").await.unwrap_err();
+        assert!(format!("{err:#}").contains("ghost"));
+    }
+
+    #[tokio::test]
+    async fn run_streamed_collects_messages_from_stdout() {
+        let sink = open_sink("ok");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("printf 'hello\\nworld\\n'");
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let outcome = run_streamed(cmd, &FakeAgent, &sink, cancelled)
+            .await
+            .unwrap();
+        assert!(outcome.stdout.contains("hello"));
+        assert!(outcome.stdout.contains("world"));
+        assert!(!outcome.natural_stop);
+        assert!(!outcome.task_complete);
+    }
+
+    #[tokio::test]
+    async fn run_streamed_detects_natural_stop_and_task_complete() {
+        let sink = open_sink("stop");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("printf 'NATURAL_STOP\\nTASK_COMPLETE\\n'");
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let outcome = run_streamed(cmd, &FakeAgent, &sink, cancelled)
+            .await
+            .unwrap();
+        assert!(outcome.natural_stop);
+        assert!(outcome.task_complete);
+    }
+
+    #[tokio::test]
+    async fn run_streamed_errors_on_nonzero_exit() {
+        let sink = open_sink("fail");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("echo bye; exit 3");
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let err = run_streamed(cmd, &FakeAgent, &sink, cancelled)
+            .await
+            .err()
+            .unwrap();
+        let msg = err.to_string();
+        assert!(msg.contains("fake"), "msg should mention agent: {msg}");
+        assert!(msg.contains("exited"), "msg should mention exit: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_streamed_bails_with_cancelled_when_flag_is_set() {
+        let sink = open_sink("cancel");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("sleep 5");
+        let cancelled = Arc::new(AtomicBool::new(true));
+        let err = run_streamed(cmd, &FakeAgent, &sink, cancelled)
+            .await
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn run_streamed_errors_when_binary_missing() {
+        let sink = open_sink("missing");
+        let cmd = Command::new("kobito-no-such-binary-xyz");
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let err = run_streamed(cmd, &FakeAgent, &sink, cancelled)
+            .await
+            .err()
+            .unwrap();
+        assert!(format!("{err:#}").contains("fake"));
+    }
+}

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -68,13 +68,12 @@ fn clean(raw: &str) -> String {
 
 fn fallback(goal: &str) -> String {
     goal.lines()
-        .next()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
         .unwrap_or("ongoing work")
         .chars()
         .take(72)
-        .collect::<String>()
-        .trim()
-        .to_string()
+        .collect()
 }
 
 #[cfg(test)]
@@ -154,5 +153,15 @@ mod tests {
     #[test]
     fn fallback_uses_default_for_empty_goal() {
         assert_eq!(fallback(""), "ongoing work");
+    }
+
+    #[test]
+    fn fallback_skips_blank_first_line() {
+        assert_eq!(fallback("   \nreal goal"), "real goal");
+    }
+
+    #[test]
+    fn fallback_uses_default_when_all_lines_blank() {
+        assert_eq!(fallback("   \n\t\n  "), "ongoing work");
     }
 }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -49,11 +49,13 @@ pub async fn generate_message(
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    let total = s.chars().count();
+    if total <= max {
         return s.to_string();
     }
-    let head = &s[..max / 2];
-    let tail = &s[s.len() - max / 2..];
+    let keep = max / 2;
+    let head: String = s.chars().take(keep).collect();
+    let tail: String = s.chars().skip(total - keep).collect();
     format!("{head}\n…\n[diff truncated]\n…\n{tail}")
 }
 
@@ -102,6 +104,17 @@ mod tests {
         assert!(out.ends_with(&"T".repeat(10)));
         assert!(out.contains("[diff truncated]"));
         assert!(!out.contains("MIDDLE"));
+    }
+
+    #[test]
+    fn truncate_handles_multibyte_chars_without_panic() {
+        let head = "あ".repeat(100);
+        let tail = "い".repeat(100);
+        let input = format!("{head}MIDDLE{tail}");
+        let out = truncate(&input, 20);
+        assert!(out.starts_with(&"あ".repeat(10)));
+        assert!(out.ends_with(&"い".repeat(10)));
+        assert!(out.contains("[diff truncated]"));
     }
 
     #[test]

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -76,3 +76,83 @@ fn fallback(goal: &str) -> String {
         .trim()
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_returns_input_when_within_limit() {
+        let s = "short diff";
+        assert_eq!(truncate(s, 100), s);
+    }
+
+    #[test]
+    fn truncate_returns_input_at_exact_limit() {
+        let s = "a".repeat(50);
+        assert_eq!(truncate(&s, 50), s);
+    }
+
+    #[test]
+    fn truncate_keeps_head_and_tail_when_over_limit() {
+        let head = "H".repeat(100);
+        let tail = "T".repeat(100);
+        let input = format!("{head}MIDDLE{tail}");
+        let out = truncate(&input, 20);
+        assert!(out.starts_with(&"H".repeat(10)));
+        assert!(out.ends_with(&"T".repeat(10)));
+        assert!(out.contains("[diff truncated]"));
+        assert!(!out.contains("MIDDLE"));
+    }
+
+    #[test]
+    fn clean_trims_surrounding_whitespace() {
+        assert_eq!(clean("  hello world  \n"), "hello world");
+    }
+
+    #[test]
+    fn clean_strips_leading_fence_and_trailing_fence() {
+        let raw = "```\nfeat: add thing\n\nbody line\n```";
+        assert_eq!(clean(raw), "feat: add thing\n\nbody line");
+    }
+
+    #[test]
+    fn clean_strips_language_tagged_fence() {
+        let raw = "```text\nfix: bug\n```";
+        assert_eq!(clean(raw), "fix: bug");
+    }
+
+    #[test]
+    fn clean_returns_empty_when_only_fence_with_no_newline() {
+        assert_eq!(clean("```"), "");
+    }
+
+    #[test]
+    fn clean_returns_empty_for_blank_input() {
+        assert_eq!(clean(""), "");
+        assert_eq!(clean("   \n  "), "");
+    }
+
+    #[test]
+    fn fallback_uses_first_line_of_goal() {
+        let goal = "implement feature\nmore details\n";
+        assert_eq!(fallback(goal), "implement feature");
+    }
+
+    #[test]
+    fn fallback_truncates_to_72_chars() {
+        let goal = "a".repeat(100);
+        let out = fallback(&goal);
+        assert_eq!(out.chars().count(), 72);
+    }
+
+    #[test]
+    fn fallback_trims_whitespace() {
+        assert_eq!(fallback("   hello   "), "hello");
+    }
+
+    #[test]
+    fn fallback_uses_default_for_empty_goal() {
+        assert_eq!(fallback(""), "ongoing work");
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -123,6 +123,19 @@ mod tests {
     use super::*;
     use std::fs;
 
+    struct TempRepo(PathBuf);
+    impl std::ops::Deref for TempRepo {
+        type Target = Path;
+        fn deref(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TempRepo {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
     fn unique_dir(label: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
             "kobito-git-{label}-{}-{}",
@@ -133,13 +146,13 @@ mod tests {
         dir
     }
 
-    fn init_repo(label: &str) -> PathBuf {
+    fn init_repo(label: &str) -> TempRepo {
         let dir = unique_dir(label);
         run(&dir, &["init", "-q", "-b", "main"]).unwrap();
         run(&dir, &["config", "user.email", "test@example.com"]).unwrap();
         run(&dir, &["config", "user.name", "Test"]).unwrap();
         run(&dir, &["config", "commit.gpgsign", "false"]).unwrap();
-        dir
+        TempRepo(dir)
     }
 
     fn write_file(repo: &Path, name: &str, content: &str) {
@@ -155,7 +168,6 @@ mod tests {
         let repo = init_repo("clean");
         empty_commit(&repo, "init");
         ensure_clean(&repo).unwrap();
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -165,7 +177,6 @@ mod tests {
         write_file(&repo, "untracked.txt", "x");
         let err = ensure_clean(&repo).unwrap_err().to_string();
         assert!(err.contains("dirty"), "expected dirty error, got: {err}");
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -173,7 +184,6 @@ mod tests {
         let repo = init_repo("curbranch");
         empty_commit(&repo, "init");
         assert_eq!(current_branch(&repo).unwrap(), "main");
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -184,7 +194,6 @@ mod tests {
         assert_eq!(current_branch(&repo).unwrap(), "feature/x");
         checkout(&repo, "main").unwrap();
         assert_eq!(current_branch(&repo).unwrap(), "main");
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -196,7 +205,6 @@ mod tests {
         assert!(!has_staged_changes(&repo).unwrap());
         stage_all(&repo).unwrap();
         assert!(has_staged_changes(&repo).unwrap());
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -210,7 +218,6 @@ mod tests {
             diff.contains("+hello"),
             "expected diff to include +hello, got: {diff}"
         );
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -222,7 +229,6 @@ mod tests {
         commit(&repo, "feat: add a").unwrap();
         let msgs = recent_commit_messages(&repo, 5).unwrap();
         assert_eq!(msgs[0], "feat: add a");
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -231,7 +237,6 @@ mod tests {
         empty_commit(&repo, "init");
         let err = commit(&repo, "noop").unwrap_err().to_string();
         assert!(err.contains("git commit failed"), "got: {err}");
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -242,7 +247,6 @@ mod tests {
         empty_commit(&repo, "third");
         let msgs = recent_commit_messages(&repo, 2).unwrap();
         assert_eq!(msgs, vec!["third".to_string(), "second".to_string()]);
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -254,14 +258,12 @@ mod tests {
         write_file(&repo, "a.txt", "v2\n");
         reset_hard(&repo).unwrap();
         assert_eq!(fs::read_to_string(repo.join("a.txt")).unwrap(), "v1\n");
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
     fn remote_url_is_none_when_no_remote_configured() {
         let repo = init_repo("noremote");
         assert!(remote_url(&repo).is_none());
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -276,7 +278,6 @@ mod tests {
             remote_url(&repo),
             Some("https://example.com/x.git".to_string())
         );
-        fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -286,6 +287,5 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("git checkout"), "got: {err}");
-        fs::remove_dir_all(&repo).ok();
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -117,3 +117,175 @@ fn run(repo: &Path, args: &[&str]) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn unique_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "kobito-git-{label}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn init_repo(label: &str) -> PathBuf {
+        let dir = unique_dir(label);
+        run(&dir, &["init", "-q", "-b", "main"]).unwrap();
+        run(&dir, &["config", "user.email", "test@example.com"]).unwrap();
+        run(&dir, &["config", "user.name", "Test"]).unwrap();
+        run(&dir, &["config", "commit.gpgsign", "false"]).unwrap();
+        dir
+    }
+
+    fn write_file(repo: &Path, name: &str, content: &str) {
+        fs::write(repo.join(name), content).unwrap();
+    }
+
+    fn empty_commit(repo: &Path, message: &str) {
+        run(repo, &["commit", "--allow-empty", "-m", message]).unwrap();
+    }
+
+    #[test]
+    fn ensure_clean_passes_for_a_clean_tree() {
+        let repo = init_repo("clean");
+        empty_commit(&repo, "init");
+        ensure_clean(&repo).unwrap();
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn ensure_clean_fails_when_tree_is_dirty() {
+        let repo = init_repo("dirty");
+        empty_commit(&repo, "init");
+        write_file(&repo, "untracked.txt", "x");
+        let err = ensure_clean(&repo).unwrap_err().to_string();
+        assert!(err.contains("dirty"), "expected dirty error, got: {err}");
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn current_branch_reports_active_branch() {
+        let repo = init_repo("curbranch");
+        empty_commit(&repo, "init");
+        assert_eq!(current_branch(&repo).unwrap(), "main");
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn create_and_checkout_then_checkout_switches_branches() {
+        let repo = init_repo("switch");
+        empty_commit(&repo, "init");
+        create_and_checkout(&repo, "feature/x").unwrap();
+        assert_eq!(current_branch(&repo).unwrap(), "feature/x");
+        checkout(&repo, "main").unwrap();
+        assert_eq!(current_branch(&repo).unwrap(), "main");
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn stage_all_and_has_staged_changes_track_index_state() {
+        let repo = init_repo("stage");
+        empty_commit(&repo, "init");
+        assert!(!has_staged_changes(&repo).unwrap());
+        write_file(&repo, "a.txt", "hello\n");
+        assert!(!has_staged_changes(&repo).unwrap());
+        stage_all(&repo).unwrap();
+        assert!(has_staged_changes(&repo).unwrap());
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn diff_staged_returns_diff_text_for_staged_files() {
+        let repo = init_repo("diff");
+        empty_commit(&repo, "init");
+        write_file(&repo, "a.txt", "hello\n");
+        stage_all(&repo).unwrap();
+        let diff = diff_staged(&repo).unwrap();
+        assert!(
+            diff.contains("+hello"),
+            "expected diff to include +hello, got: {diff}"
+        );
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn commit_creates_revision_with_given_message() {
+        let repo = init_repo("commit");
+        empty_commit(&repo, "init");
+        write_file(&repo, "a.txt", "hi\n");
+        stage_all(&repo).unwrap();
+        commit(&repo, "feat: add a").unwrap();
+        let msgs = recent_commit_messages(&repo, 5).unwrap();
+        assert_eq!(msgs[0], "feat: add a");
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn commit_fails_when_nothing_is_staged() {
+        let repo = init_repo("commit-empty");
+        empty_commit(&repo, "init");
+        let err = commit(&repo, "noop").unwrap_err().to_string();
+        assert!(err.contains("git commit failed"), "got: {err}");
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn recent_commit_messages_returns_subjects_in_order() {
+        let repo = init_repo("log");
+        empty_commit(&repo, "first");
+        empty_commit(&repo, "second");
+        empty_commit(&repo, "third");
+        let msgs = recent_commit_messages(&repo, 2).unwrap();
+        assert_eq!(msgs, vec!["third".to_string(), "second".to_string()]);
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn reset_hard_drops_unstaged_modifications() {
+        let repo = init_repo("reset");
+        write_file(&repo, "a.txt", "v1\n");
+        stage_all(&repo).unwrap();
+        commit(&repo, "init a").unwrap();
+        write_file(&repo, "a.txt", "v2\n");
+        reset_hard(&repo).unwrap();
+        assert_eq!(fs::read_to_string(repo.join("a.txt")).unwrap(), "v1\n");
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn remote_url_is_none_when_no_remote_configured() {
+        let repo = init_repo("noremote");
+        assert!(remote_url(&repo).is_none());
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn remote_url_returns_configured_origin() {
+        let repo = init_repo("remote");
+        run(
+            &repo,
+            &["remote", "add", "origin", "https://example.com/x.git"],
+        )
+        .unwrap();
+        assert_eq!(
+            remote_url(&repo),
+            Some("https://example.com/x.git".to_string())
+        );
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn run_returns_error_with_stderr_when_git_fails() {
+        let repo = init_repo("run-fail");
+        let err = run(&repo, &["checkout", "does-not-exist"])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("git checkout"), "got: {err}");
+        fs::remove_dir_all(&repo).ok();
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -256,3 +256,242 @@ fn section_for(line: &str) -> (&'static str, Option<&'static str>, bool) {
         (BODY_BG, None, false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process;
+
+    fn unique_tmp(label: &str) -> PathBuf {
+        let ts = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+        let p = std::env::temp_dir().join(format!("kobito-logger-{label}-{}-{ts}", process::id()));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn format_count_renders_compact_units() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(999), "999");
+        assert_eq!(format_count(1_000), "1.0k");
+        assert_eq!(format_count(1_500), "1.5k");
+        assert_eq!(format_count(1_000_000), "1.0M");
+        assert_eq!(format_count(1_500_000), "1.5M");
+    }
+
+    #[test]
+    fn format_event_returns_none_for_blank_message() {
+        assert!(format_event(&AgentEvent::Message(String::new())).is_none());
+        assert!(format_event(&AgentEvent::Message("\n\n".into())).is_none());
+    }
+
+    #[test]
+    fn format_event_trims_trailing_newlines_on_message() {
+        let s = format_event(&AgentEvent::Message("hello\n\n".into())).unwrap();
+        assert_eq!(s, "hello");
+    }
+
+    #[test]
+    fn format_event_renders_tool_start_with_and_without_summary() {
+        let with = format_event(&AgentEvent::ToolStart {
+            tool: "Read".into(),
+            summary: Some("file.rs".into()),
+        })
+        .unwrap();
+        assert_eq!(with, "▶ Read: file.rs");
+
+        let without = format_event(&AgentEvent::ToolStart {
+            tool: "Read".into(),
+            summary: None,
+        })
+        .unwrap();
+        assert_eq!(without, "▶ Read");
+    }
+
+    #[test]
+    fn format_event_only_renders_failed_tool_end() {
+        let ok = format_event(&AgentEvent::ToolEnd {
+            tool: "Read".into(),
+            ok: true,
+        });
+        assert!(ok.is_none());
+        let failed = format_event(&AgentEvent::ToolEnd {
+            tool: "Read".into(),
+            ok: false,
+        })
+        .unwrap();
+        assert_eq!(failed, "✗ Read");
+    }
+
+    #[test]
+    fn format_event_renders_stop_reason() {
+        let s = format_event(&AgentEvent::Stop {
+            reason: "natural".into(),
+        })
+        .unwrap();
+        assert_eq!(s, "(stop: natural)");
+    }
+
+    #[test]
+    fn format_event_drops_usage_and_other() {
+        assert!(format_event(&AgentEvent::Usage(Usage::default())).is_none());
+        assert!(format_event(&AgentEvent::Other("debug".into())).is_none());
+    }
+
+    #[test]
+    fn section_for_marks_major_headers_bold() {
+        for header in [
+            "kobito start",
+            "kobito resume foo",
+            "project: kobito",
+            "═══════",
+            "── line",
+            "=== task 1 ===",
+            "✓ committed abc",
+            "✓ PR opened",
+        ] {
+            let (_, fg, bold) = section_for(header);
+            assert!(bold, "expected bold for {header:?}");
+            assert!(fg.is_some());
+        }
+    }
+
+    #[test]
+    fn section_for_marks_summary_lines_non_bold() {
+        for line in [
+            "done iter 1",
+            "  tokens — 100",
+            "agent reported NATURAL_STOP",
+        ] {
+            let (_, fg, bold) = section_for(line);
+            assert!(!bold, "expected non-bold for {line:?}");
+            assert!(fg.is_some());
+        }
+    }
+
+    #[test]
+    fn section_for_routes_errors_to_maroon_bg() {
+        for err in ["✗ failed", "interrupting agent"] {
+            let (bg, _, bold) = section_for(err);
+            assert!(bold);
+            assert!(bg.contains("50;22;26"), "expected maroon bg for {err:?}");
+        }
+    }
+
+    #[test]
+    fn section_for_classifies_tool_calls_and_body() {
+        let (_, fg, bold) = section_for("▶ Read");
+        assert!(!bold);
+        assert!(fg.is_some());
+
+        let (bg, fg, bold) = section_for("plain agent body");
+        assert!(!bold);
+        assert!(fg.is_none());
+        assert!(bg.contains("18;19;22"));
+    }
+
+    #[test]
+    fn colorize_wraps_with_reset_sequence() {
+        let s = colorize("hello", "padding hello");
+        assert!(s.starts_with("\x1b["));
+        assert!(s.ends_with("\x1b[K\x1b[0m"));
+        assert!(s.contains("padding hello"));
+    }
+
+    #[test]
+    fn open_creates_log_and_events_files() {
+        let dir = unique_tmp("open");
+        let log_path = dir.join("log.ndjson");
+        let _sink = LogSink::open(&log_path, None).expect("open should succeed");
+        assert!(log_path.exists());
+        assert!(dir.join("events.ndjson").exists());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn write_appends_a_json_line_to_log() {
+        let dir = unique_tmp("write");
+        let log_path = dir.join("log.ndjson");
+        let sink = LogSink::open(&log_path, None).unwrap();
+        sink.write("agent", "hello");
+        let body = fs::read_to_string(&log_path).unwrap();
+        assert!(body.contains("\"source\":\"agent\""));
+        assert!(body.contains("\"line\":\"hello\""));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn note_records_under_kobito_source() {
+        let dir = unique_tmp("note");
+        let log_path = dir.join("log.ndjson");
+        let sink = LogSink::open(&log_path, None).unwrap();
+        sink.note("starting up");
+        let body = fs::read_to_string(&log_path).unwrap();
+        assert!(body.contains("\"source\":\"kobito\""));
+        assert!(body.contains("starting up"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_raw_event_appends_to_events_file() {
+        let dir = unique_tmp("raw");
+        let log_path = dir.join("log.ndjson");
+        let sink = LogSink::open(&log_path, None).unwrap();
+        sink.record_raw_event("{\"k\":1}");
+        let body = fs::read_to_string(dir.join("events.ndjson")).unwrap();
+        assert!(body.contains("\"raw\""));
+        assert!(body.contains("{\\\"k\\\":1}"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn event_writes_message_and_skips_silent_variants() {
+        let dir = unique_tmp("event");
+        let log_path = dir.join("log.ndjson");
+        let sink = LogSink::open(&log_path, None).unwrap();
+        sink.event(&AgentEvent::Message("payload".into()));
+        sink.event(&AgentEvent::Usage(Usage {
+            input_tokens: 5,
+            output_tokens: 7,
+            cached_input_tokens: 0,
+        }));
+        sink.event(&AgentEvent::Other("debug".into()));
+        let body = fs::read_to_string(&log_path).unwrap();
+        assert!(body.contains("payload"));
+        let lines = body.lines().count();
+        assert_eq!(lines, 1, "only the Message event should be persisted");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn event_usage_updates_internal_state() {
+        let dir = unique_tmp("usage");
+        let log_path = dir.join("log.ndjson");
+        let sink = LogSink::open(&log_path, None).unwrap();
+        sink.event(&AgentEvent::Usage(Usage {
+            input_tokens: 11,
+            output_tokens: 22,
+            cached_input_tokens: 0,
+        }));
+        let s = sink.state.lock().unwrap();
+        assert_eq!(s.usage.input_tokens, 11);
+        assert_eq!(s.usage.output_tokens, 22);
+        drop(s);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn set_iteration_status_updates_state_without_a_bar() {
+        let dir = unique_tmp("status");
+        let log_path = dir.join("log.ndjson");
+        let sink = LogSink::open(&log_path, None).unwrap();
+        sink.set_iteration_status(2, 3, "running");
+        let s = sink.state.lock().unwrap();
+        assert_eq!(s.retries, 3);
+        assert_eq!(s.state_label, "running");
+        drop(s);
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -72,6 +72,18 @@ fn append_section(path: &Path, iteration: u32, body: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn unique_path(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "kobito-notes-{label}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("notes.md")
+    }
 
     #[test]
     fn clean_strips_fences() {
@@ -85,8 +97,25 @@ mod tests {
     }
 
     #[test]
+    fn clean_returns_empty_for_blank() {
+        assert_eq!(clean(""), "");
+        assert_eq!(clean("   \n  "), "");
+    }
+
+    #[test]
+    fn clean_handles_fence_without_newline() {
+        assert_eq!(clean("```"), "");
+    }
+
+    #[test]
     fn excerpt_passes_through_when_short() {
         assert_eq!(excerpt("short", 100), "short");
+    }
+
+    #[test]
+    fn excerpt_passes_through_at_exact_limit() {
+        let s = "a".repeat(50);
+        assert_eq!(excerpt(&s, 50), s);
     }
 
     #[test]
@@ -95,5 +124,62 @@ mod tests {
         let out = excerpt(&s, 4_000);
         assert!(out.contains("[diff truncated]"));
         assert!(out.len() < 5_000);
+    }
+
+    #[test]
+    fn excerpt_keeps_head_and_tail_markers() {
+        let head = "H".repeat(100);
+        let tail = "T".repeat(100);
+        let input = format!("{head}MIDDLE{tail}");
+        let out = excerpt(&input, 20);
+        assert!(out.starts_with(&"H".repeat(10)));
+        assert!(out.ends_with(&"T".repeat(10)));
+        assert!(!out.contains("MIDDLE"));
+    }
+
+    #[test]
+    fn append_section_creates_file_when_missing() {
+        let path = unique_path("create");
+        assert!(!path.exists());
+        append_section(&path, 1, "- learning one").unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("## iteration 1 —"));
+        assert!(contents.contains("- learning one"));
+        assert!(contents.ends_with('\n'));
+    }
+
+    #[test]
+    fn append_section_appends_to_existing_file() {
+        let path = unique_path("append");
+        fs::write(&path, "preexisting\n").unwrap();
+        append_section(&path, 2, "- new note").unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.starts_with("preexisting\n"));
+        assert!(contents.contains("## iteration 2 —"));
+        assert!(contents.contains("- new note"));
+    }
+
+    #[test]
+    fn append_section_supports_multiple_iterations() {
+        let path = unique_path("multi");
+        append_section(&path, 1, "- first").unwrap();
+        append_section(&path, 2, "- second").unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("## iteration 1 —"));
+        assert!(contents.contains("## iteration 2 —"));
+        let pos1 = contents.find("- first").unwrap();
+        let pos2 = contents.find("- second").unwrap();
+        assert!(pos1 < pos2);
+    }
+
+    #[test]
+    fn append_section_returns_error_when_path_is_directory() {
+        let dir = std::env::temp_dir().join(format!(
+            "kobito-notes-dirpath-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        assert!(append_section(&dir, 1, "x").is_err());
     }
 }

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -40,11 +40,13 @@ pub async fn append_learning(
 }
 
 fn excerpt(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    let total = s.chars().count();
+    if total <= max {
         return s.to_string();
     }
-    let head = &s[..max / 2];
-    let tail = &s[s.len() - max / 2..];
+    let keep = max / 2;
+    let head: String = s.chars().take(keep).collect();
+    let tail: String = s.chars().skip(total - keep).collect();
     format!("{head}\n…\n[diff truncated]\n…\n{tail}")
 }
 
@@ -135,6 +137,17 @@ mod tests {
         assert!(out.starts_with(&"H".repeat(10)));
         assert!(out.ends_with(&"T".repeat(10)));
         assert!(!out.contains("MIDDLE"));
+    }
+
+    #[test]
+    fn excerpt_handles_multibyte_chars_without_panic() {
+        let head = "あ".repeat(100);
+        let tail = "い".repeat(100);
+        let input = format!("{head}MIDDLE{tail}");
+        let out = excerpt(&input, 20);
+        assert!(out.starts_with(&"あ".repeat(10)));
+        assert!(out.ends_with(&"い".repeat(10)));
+        assert!(out.contains("[diff truncated]"));
     }
 
     #[test]

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -113,7 +113,11 @@ mod tests {
     #[test]
     fn config_root_path_ends_with_kobito() {
         let root = config_root();
-        assert_eq!(root.file_name().and_then(|s| s.to_str()), Some("kobito"));
+        let leaf = root.file_name().and_then(|s| s.to_str());
+        assert!(
+            matches!(leaf, Some("kobito" | ".kobito-config")),
+            "unexpected config_root leaf: {leaf:?}"
+        );
     }
 
     #[test]

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -92,6 +92,69 @@ mod tests {
             .collect()
     }
 
+    fn unique_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "kobito-preset-{label}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_local_preset(repo: &Path, name: &str, body: &str) -> PathBuf {
+        let dir = repo.join(".kobito/presets");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{name}.md"));
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn config_root_path_ends_with_kobito() {
+        let root = config_root();
+        assert_eq!(root.file_name().and_then(|s| s.to_str()), Some("kobito"));
+    }
+
+    #[test]
+    fn resolve_returns_local_preset_when_present() {
+        let repo = unique_dir("resolve-local");
+        let expected = write_local_preset(&repo, "cover", "body");
+        let found = resolve("cover", &repo).unwrap();
+        assert_eq!(found, expected);
+    }
+
+    #[test]
+    fn resolve_errors_when_preset_missing_in_both_locations() {
+        let repo = unique_dir("resolve-missing");
+        let unique_name = format!(
+            "no-such-preset-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        );
+        let err = resolve(&unique_name, &repo).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not found"));
+        assert!(msg.contains(&unique_name));
+    }
+
+    #[test]
+    fn load_reads_preset_and_substitutes_variables() {
+        let repo = unique_dir("load");
+        write_local_preset(&repo, "iter", "Cover {{path}} to {{target}}%");
+        let v = vars(&[("path", "src/api"), ("target", "80")]);
+        let out = load("iter", &repo, &v).unwrap();
+        assert_eq!(out, "Cover src/api to 80%");
+    }
+
+    #[test]
+    fn load_propagates_substitute_errors_for_missing_vars() {
+        let repo = unique_dir("load-missing");
+        write_local_preset(&repo, "iter", "Cover {{path}}");
+        let err = load("iter", &repo, &HashMap::new()).unwrap_err();
+        assert!(err.to_string().contains("path"));
+    }
+
     #[test]
     fn substitute_replaces_variables() {
         let v = vars(&[("path", "src/api"), ("target", "80")]);

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -111,3 +111,147 @@ pub fn save_prompt(prompts_dir: &Path, iteration: u32, body: &str) -> Result<()>
     fs::write(path, body)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parts(goal: &str, iteration: u32) -> PromptParts {
+        PromptParts {
+            goal: goal.to_string(),
+            iteration,
+            notes: None,
+            preset: None,
+        }
+    }
+
+    #[test]
+    fn iteration_prompt_includes_meta_goal_and_iteration() {
+        let out = build_iteration_prompt(&parts("ship the thing", 7));
+        assert!(out.starts_with("# About this run"));
+        assert!(out.contains("NATURAL_STOP"));
+        assert!(out.contains("## Goal\n\nship the thing"));
+        assert!(out.contains("## Iteration 7"));
+    }
+
+    #[test]
+    fn iteration_prompt_trims_goal() {
+        let out = build_iteration_prompt(&parts("  padded goal  \n", 1));
+        assert!(out.contains("## Goal\n\npadded goal\n"));
+    }
+
+    #[test]
+    fn iteration_prompt_omits_notes_section_when_absent() {
+        let out = build_iteration_prompt(&parts("g", 1));
+        assert!(!out.contains("## Cross-iteration notes"));
+    }
+
+    #[test]
+    fn iteration_prompt_omits_notes_section_when_blank() {
+        let mut p = parts("g", 1);
+        p.notes = Some("   \n  ".into());
+        let out = build_iteration_prompt(&p);
+        assert!(!out.contains("## Cross-iteration notes"));
+    }
+
+    #[test]
+    fn iteration_prompt_includes_notes_when_present() {
+        let mut p = parts("g", 1);
+        p.notes = Some("- learned X\n- avoid Y".into());
+        let out = build_iteration_prompt(&p);
+        assert!(out.contains("## Cross-iteration notes\n\n- learned X\n- avoid Y\n\n"));
+    }
+
+    #[test]
+    fn iteration_prompt_includes_preset_before_notes() {
+        let mut p = parts("g", 1);
+        p.preset = Some("PRESET BODY".into());
+        p.notes = Some("NOTES".into());
+        let out = build_iteration_prompt(&p);
+        let preset_idx = out.find("PRESET BODY").unwrap();
+        let notes_idx = out.find("## Cross-iteration notes").unwrap();
+        let goal_idx = out.find("## Goal").unwrap();
+        assert!(preset_idx < notes_idx);
+        assert!(notes_idx < goal_idx);
+    }
+
+    #[test]
+    fn iteration_prompt_ends_with_focus_directive() {
+        let out = build_iteration_prompt(&parts("g", 1));
+        assert!(out.trim_end().ends_with(
+            "Make a small, self-contained improvement toward the goal. Stop when one logical change is complete so the diff can be committed."
+        ));
+    }
+
+    #[test]
+    fn task_prompt_includes_meta_body_and_iteration() {
+        let out = build_task_prompt(&parts("ignored goal", 3), "wire up X");
+        assert!(out.starts_with("# About this run"));
+        assert!(out.contains("TASK_COMPLETE"));
+        assert!(out.contains("## Single task\n\nwire up X"));
+        assert!(out.contains("## Iteration 3"));
+    }
+
+    #[test]
+    fn task_prompt_does_not_use_continuous_meta() {
+        let out = build_task_prompt(&parts("g", 1), "task");
+        assert!(!out.contains("NATURAL_STOP"));
+    }
+
+    #[test]
+    fn task_prompt_omits_notes_when_blank() {
+        let mut p = parts("g", 1);
+        p.notes = Some("\n".into());
+        let out = build_task_prompt(&p, "task");
+        assert!(!out.contains("## Cross-iteration notes"));
+    }
+
+    #[test]
+    fn task_prompt_includes_preset_and_notes() {
+        let mut p = parts("g", 2);
+        p.preset = Some("PRESET".into());
+        p.notes = Some("a note".into());
+        let out = build_task_prompt(&p, "do thing");
+        assert!(out.contains("PRESET"));
+        assert!(out.contains("## Cross-iteration notes\n\na note"));
+        assert!(out.contains("## Single task\n\ndo thing"));
+    }
+
+    #[test]
+    fn task_prompt_ends_with_focus_directive() {
+        let out = build_task_prompt(&parts("g", 1), "task");
+        assert!(out.trim_end().ends_with(
+            "Make focused progress toward completing only this single task. Stop when one logical change is complete so the diff can be committed."
+        ));
+    }
+
+    #[test]
+    fn save_prompt_writes_padded_filename() {
+        let dir = std::env::temp_dir().join(format!(
+            "kobito-prompt-test-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        save_prompt(&dir, 5, "hello body").unwrap();
+        let path = dir.join("iter-0005.md");
+        let body = fs::read_to_string(&path).unwrap();
+        assert_eq!(body, "hello body");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn save_prompt_overwrites_existing_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "kobito-prompt-overwrite-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        save_prompt(&dir, 1, "first").unwrap();
+        save_prompt(&dir, 1, "second").unwrap();
+        let body = fs::read_to_string(dir.join("iter-0001.md")).unwrap();
+        assert_eq!(body, "second");
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -179,3 +179,207 @@ pub fn list_projects() -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "kobito-state-{label}-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0),
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn project_with_root(root: PathBuf, id: &str) -> ProjectPaths {
+        fs::create_dir_all(root.join("runs")).unwrap();
+        ProjectPaths {
+            id: id.to_string(),
+            root,
+        }
+    }
+
+    fn sample_meta(run_id: &str) -> RunMeta {
+        RunMeta {
+            run_id: run_id.to_string(),
+            started_at: "2026-05-01T00:00:00Z".to_string(),
+            branch: "feature/x".to_string(),
+            goal: "do thing".to_string(),
+            agent: "claude_code".to_string(),
+        }
+    }
+
+    #[test]
+    fn project_id_starts_with_basename_and_8_hex_suffix() {
+        let id = project_id(
+            Path::new("/tmp/myproj"),
+            Some("https://example.com/myproj.git"),
+        );
+        let (basename, suffix) = id.rsplit_once('-').unwrap();
+        assert_eq!(basename, "myproj");
+        assert_eq!(suffix.len(), 8);
+        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn project_id_is_stable_for_same_remote_url() {
+        let a = project_id(Path::new("/x/proj"), Some("git@github.com:o/r.git"));
+        let b = project_id(Path::new("/elsewhere/proj"), Some("git@github.com:o/r.git"));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn project_id_falls_back_to_path_when_no_remote() {
+        let a = project_id(Path::new("/some/where/proj"), None);
+        let b = project_id(Path::new("/other/proj"), None);
+        assert!(a.starts_with("proj-"));
+        assert!(b.starts_with("proj-"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn project_id_uses_default_basename_when_path_has_none() {
+        let id = project_id(Path::new("/"), Some("remote"));
+        assert!(id.starts_with("project-"));
+    }
+
+    #[test]
+    fn new_run_creates_run_dir_prompts_and_empty_log() {
+        let dir = unique_dir("new-run");
+        let project = project_with_root(dir.clone(), "p-1");
+        let run = new_run(project).unwrap();
+        assert!(run.run_dir.exists());
+        assert!(run.prompts_dir.exists());
+        assert!(run.log_file.exists());
+        assert_eq!(fs::read_to_string(&run.log_file).unwrap(), "");
+        assert!(!run.timestamp.is_empty());
+        assert_eq!(run.run_dir.file_name().unwrap(), run.timestamp.as_str());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_run_meta_round_trips_written_meta() {
+        let dir = unique_dir("meta-rt");
+        let project = project_with_root(dir.clone(), "p-2");
+        let run = new_run(project.clone()).unwrap();
+        write_run_meta(&run, &sample_meta(&run.timestamp)).unwrap();
+        let (loaded, paths) = read_run_meta(&project, &run.timestamp).unwrap();
+        assert_eq!(loaded.branch, "feature/x");
+        assert_eq!(loaded.goal, "do thing");
+        assert_eq!(loaded.agent, "claude_code");
+        assert_eq!(paths.run_dir, run.run_dir);
+        assert_eq!(paths.timestamp, run.timestamp);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_run_meta_errors_when_run_missing() {
+        let dir = unique_dir("meta-missing");
+        let project = project_with_root(dir.clone(), "p-3");
+        let err = read_run_meta(&project, "no-such-run").unwrap_err();
+        assert!(format!("{err:#}").contains("not found"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn recent_runs_returns_empty_when_runs_dir_missing() {
+        let dir = unique_dir("recent-empty");
+        let project = ProjectPaths {
+            id: "p".to_string(),
+            root: dir.clone(),
+        };
+        assert!(recent_runs(&project, 5).unwrap().is_empty());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn recent_runs_sorts_desc_and_truncates_to_limit() {
+        let dir = unique_dir("recent-sort");
+        let project = project_with_root(dir.clone(), "p-4");
+        for id in ["2026-01-01T00-00-00", "2026-03-01T00-00-00", "2026-02-01T00-00-00"] {
+            let rd = project.root.join("runs").join(id);
+            fs::create_dir_all(&rd).unwrap();
+            fs::write(
+                rd.join("meta.json"),
+                serde_json::to_string(&sample_meta(id)).unwrap(),
+            )
+            .unwrap();
+        }
+        let summaries = recent_runs(&project, 2).unwrap();
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].id, "2026-03-01T00-00-00");
+        assert_eq!(summaries[1].id, "2026-02-01T00-00-00");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn recent_runs_skips_dirs_without_meta_json() {
+        let dir = unique_dir("recent-skip");
+        let project = project_with_root(dir.clone(), "p-5");
+        fs::create_dir_all(project.root.join("runs").join("orphan")).unwrap();
+        assert!(recent_runs(&project, 5).unwrap().is_empty());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn notes_path_and_tasks_path_match_layout() {
+        let dir = unique_dir("paths");
+        let project = ProjectPaths {
+            id: "p".to_string(),
+            root: dir.clone(),
+        };
+        let run = RunPaths {
+            project: project.clone(),
+            run_dir: dir.join("runs/r1"),
+            log_file: dir.join("runs/r1/log.ndjson"),
+            prompts_dir: dir.join("runs/r1/prompts"),
+            timestamp: "r1".to_string(),
+        };
+        assert_eq!(notes_path(&run), dir.join("runs/r1/notes.md"));
+        assert_eq!(tasks_path(&project), dir.join("tasks.md"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn seed_tasks_copies_from_repo_kobito_dir() {
+        let dir = unique_dir("seed-copy");
+        let project = project_with_root(dir.clone(), "p-6");
+        let repo = unique_dir("seed-copy-repo");
+        fs::create_dir_all(repo.join(".kobito")).unwrap();
+        fs::write(repo.join(".kobito/tasks.md"), "- [ ] do x\n").unwrap();
+        let dest = seed_tasks_if_needed(&project, &repo).unwrap();
+        assert_eq!(dest, project.root.join("tasks.md"));
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "- [ ] do x\n");
+        fs::remove_dir_all(&dir).ok();
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn seed_tasks_creates_empty_file_when_repo_has_none() {
+        let dir = unique_dir("seed-empty");
+        let project = project_with_root(dir.clone(), "p-7");
+        let repo = unique_dir("seed-empty-repo");
+        let dest = seed_tasks_if_needed(&project, &repo).unwrap();
+        assert!(dest.exists());
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "");
+        fs::remove_dir_all(&dir).ok();
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn seed_tasks_is_idempotent_when_dest_already_present() {
+        let dir = unique_dir("seed-idem");
+        let project = project_with_root(dir.clone(), "p-8");
+        fs::write(project.root.join("tasks.md"), "existing\n").unwrap();
+        let repo = unique_dir("seed-idem-repo");
+        fs::create_dir_all(repo.join(".kobito")).unwrap();
+        fs::write(repo.join(".kobito/tasks.md"), "should NOT overwrite\n").unwrap();
+        let dest = seed_tasks_if_needed(&project, &repo).unwrap();
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "existing\n");
+        fs::remove_dir_all(&dir).ok();
+        fs::remove_dir_all(&repo).ok();
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -299,7 +299,11 @@ mod tests {
     fn recent_runs_sorts_desc_and_truncates_to_limit() {
         let dir = unique_dir("recent-sort");
         let project = project_with_root(dir.clone(), "p-4");
-        for id in ["2026-01-01T00-00-00", "2026-03-01T00-00-00", "2026-02-01T00-00-00"] {
+        for id in [
+            "2026-01-01T00-00-00",
+            "2026-03-01T00-00-00",
+            "2026-02-01T00-00-00",
+        ] {
             let rd = project.root.join("runs").join(id);
             fs::create_dir_all(&rd).unwrap();
             fs::write(


### PR DESCRIPTION
## Summary

- 11 commits adding unit tests to modules that were previously uncovered or undercovered, produced by an autonomous coverage-up loop running against this branch.
- Net effect: overall line coverage reaches **~75.77%** (`cargo llvm-cov --workspace --summary-only`).
- Tests-only — no production behavior changes.

## Commits

- `601c91d` test(prompt): cover iteration/task prompt builders and save_prompt
- `5d94245` test(state): cover project_id, run lifecycle, and tasks seeding
- `41d84c6` test(git): cover ensure_clean, branch ops, staging, commit, and remote helpers
- `46f756f` test(preset): cover config_root, resolve, and load helpers
- `d76fb46` test(agent/codex): cover command builders and event parsing
- `a08de8c` test(agent/claude_code): cover command builders, event parsing, and input summary
- `683f3d4` test(commit): cover truncate, clean, and fallback helpers
- `c29ac0b` test(notes): cover clean edge cases, excerpt boundaries, and append_section
- `db2445b` test(agent): cover from_name dispatch and unknown agent errors
- `dcb520c` test(logger): cover formatters, section routing, and LogSink writes
- `7784208` test(agent/stream): cover run_oneshot and run_streamed paths

The final commit (`7784208`) was salvaged manually: its iteration's diff embeds the literal sentinels `NATURAL_STOP` / `TASK_COMPLETE` as fixture data, which retripped kobito's own substring-based loop-termination heuristic and caused the run to exit before that iteration could be auto-committed. The underlying flaw is tracked as #28.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo test --bin kobito` — 164 passed, 0 failed
- [x] `cargo check` clean
- [ ] CI green on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites across the agent, git integration, logging, prompt generation, state management, and utility modules to improve code reliability and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->