### PR TITLE
fix: terminate loop on JSON in agent's final message, not text sentinels

### DIFF
--- a/src/agent/stream.rs
+++ b/src/agent/stream.rs
@@ -44,6 +44,7 @@ pub async fn run_streamed(
     });
 
     let mut accumulated = String::new();
+    let mut last_message: Option<String> = None;
     let mut usage = Usage::default();
     let mut reader = BufReader::new(stdout).lines();
     let mut interrupted = false;
@@ -64,6 +65,7 @@ pub async fn run_streamed(
                                 AgentEvent::Message(text) => {
                                     accumulated.push_str(text);
                                     accumulated.push('\n');
+                                    last_message = Some(text.clone());
                                 }
                                 AgentEvent::Usage(u) => {
                                     usage = *u;
@@ -91,14 +93,50 @@ pub async fn run_streamed(
     if !status.success() {
         bail!("{name} exited with status {status}");
     }
-    let natural_stop = accumulated.contains("NATURAL_STOP");
-    let task_complete = accumulated.contains("TASK_COMPLETE");
+    let (natural_stop, task_complete) = parse_stop_signal(last_message.as_deref());
     Ok(AgentOutcome {
         stdout: accumulated,
         natural_stop,
         task_complete,
         usage,
     })
+}
+
+/// Parse the agent's *final* `Message` text as a JSON object describing
+/// loop termination. Anything that is not a valid JSON object, or lacks
+/// the recognised boolean fields, is treated as "keep going".
+///
+/// We deliberately look only at the final Message (and only at *its*
+/// content), so source code, diffs, fixtures, or commentary that mention
+/// the field names earlier in the response cannot accidentally end the
+/// loop. See issue #28.
+fn parse_stop_signal(text: Option<&str>) -> (bool, bool) {
+    let Some(text) = text else {
+        return (false, false);
+    };
+    let body = strip_code_fence(text.trim());
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&body) else {
+        return (false, false);
+    };
+    (
+        v.get("natural_stop")
+            .and_then(|x| x.as_bool())
+            .unwrap_or(false),
+        v.get("task_complete")
+            .and_then(|x| x.as_bool())
+            .unwrap_or(false),
+    )
+}
+
+fn strip_code_fence(s: &str) -> String {
+    let mut t = s.trim();
+    if let Some(rest) = t.strip_prefix("```json").or_else(|| t.strip_prefix("```")) {
+        t = rest.trim();
+    }
+    if let Some(rest) = t.strip_suffix("```") {
+        t = rest.trim();
+    }
+    t.to_string()
 }
 
 pub async fn run_oneshot(mut cmd: Command, name: &str) -> Result<String> {
@@ -202,8 +240,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_streamed_detects_natural_stop_and_task_complete() {
+    async fn run_streamed_detects_stop_signal_from_final_json() {
         let (sink, _dir) = open_sink("stop");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("printf 'doing some work\\n{\"natural_stop\":true,\"task_complete\":true}\\n'");
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let outcome = run_streamed(cmd, &FakeAgent, &sink, cancelled)
+            .await
+            .unwrap();
+        assert!(outcome.natural_stop);
+        assert!(outcome.task_complete);
+    }
+
+    #[tokio::test]
+    async fn run_streamed_ignores_stop_field_in_intermediate_messages() {
+        // Regression for #28: an intermediate Message that quotes the
+        // sentinel must not end the loop. Only the *final* message is
+        // parsed as JSON.
+        let (sink, _dir) = open_sink("intermediate");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(
+            "printf 'discussed {\"natural_stop\":true} in a test fixture\\nfinal commentary\\n'",
+        );
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let outcome = run_streamed(cmd, &FakeAgent, &sink, cancelled)
+            .await
+            .unwrap();
+        assert!(!outcome.natural_stop);
+        assert!(!outcome.task_complete);
+    }
+
+    #[tokio::test]
+    async fn run_streamed_ignores_legacy_uppercase_sentinels() {
+        // The previous implementation used substring matching on
+        // NATURAL_STOP / TASK_COMPLETE; tests that contain those
+        // tokens as fixture data must no longer trigger termination.
+        let (sink, _dir) = open_sink("legacy");
         let mut cmd = Command::new("sh");
         cmd.arg("-c")
             .arg("printf 'NATURAL_STOP\\nTASK_COMPLETE\\n'");
@@ -211,8 +284,8 @@ mod tests {
         let outcome = run_streamed(cmd, &FakeAgent, &sink, cancelled)
             .await
             .unwrap();
-        assert!(outcome.natural_stop);
-        assert!(outcome.task_complete);
+        assert!(!outcome.natural_stop);
+        assert!(!outcome.task_complete);
     }
 
     #[tokio::test]
@@ -253,5 +326,78 @@ mod tests {
             .err()
             .unwrap();
         assert!(format!("{err:#}").contains("fake"));
+    }
+
+    #[test]
+    fn parse_stop_signal_returns_false_for_none() {
+        assert_eq!(parse_stop_signal(None), (false, false));
+    }
+
+    #[test]
+    fn parse_stop_signal_returns_false_for_non_json_text() {
+        assert_eq!(
+            parse_stop_signal(Some("just a free-form summary")),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn parse_stop_signal_extracts_natural_stop() {
+        assert_eq!(
+            parse_stop_signal(Some(r#"{"natural_stop": true}"#)),
+            (true, false)
+        );
+    }
+
+    #[test]
+    fn parse_stop_signal_extracts_task_complete() {
+        assert_eq!(
+            parse_stop_signal(Some(r#"{"task_complete": true}"#)),
+            (false, true)
+        );
+    }
+
+    #[test]
+    fn parse_stop_signal_extracts_both_flags() {
+        assert_eq!(
+            parse_stop_signal(Some(
+                r#"{"natural_stop": true, "task_complete": true, "summary": "done"}"#
+            )),
+            (true, true)
+        );
+    }
+
+    #[test]
+    fn parse_stop_signal_defaults_missing_fields_to_false() {
+        assert_eq!(
+            parse_stop_signal(Some(r#"{"summary": "wip"}"#)),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn parse_stop_signal_treats_non_bool_field_as_false() {
+        assert_eq!(
+            parse_stop_signal(Some(r#"{"natural_stop": "yes"}"#)),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn parse_stop_signal_strips_plain_code_fence() {
+        let body = "```\n{\"natural_stop\": true}\n```";
+        assert_eq!(parse_stop_signal(Some(body)), (true, false));
+    }
+
+    #[test]
+    fn parse_stop_signal_strips_json_code_fence() {
+        let body = "```json\n{\"task_complete\": true}\n```";
+        assert_eq!(parse_stop_signal(Some(body)), (false, true));
+    }
+
+    #[test]
+    fn parse_stop_signal_tolerates_surrounding_whitespace() {
+        let body = "\n   {\"natural_stop\": true}   \n";
+        assert_eq!(parse_stop_signal(Some(body)), (true, false));
     }
 }

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -161,7 +161,7 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                         out.usage.cached_input_tokens,
                     ));
                     if out.task_complete {
-                        sink.note("agent reported TASK_COMPLETE");
+                        sink.note("agent reported task_complete");
                         completed = true;
                         break;
                     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -363,7 +363,7 @@ mod tests {
         for line in [
             "done iter 1",
             "  tokens — 100",
-            "agent reported NATURAL_STOP",
+            "agent reported natural_stop",
         ] {
             let (_, fg, bold) = section_for(line);
             assert!(!bold, "expected non-bold for {line:?}");

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -21,9 +21,18 @@ Each invocation of you is one iteration:
 - Use `git log` on the current branch to see what previous iterations of *this* run \
   accomplished — your previous self has no in-process memory across iterations.
 - Any learnings you wrote in earlier iterations appear below under \"Cross-iteration notes\".
-- When the goal is fully reached or no meaningful work remains, output the literal token \
-  `NATURAL_STOP` on its own line and stop. The loop will exit cleanly. Otherwise make a \
-  small focused change and stop so it can be committed.
+
+## How to stop
+
+Your **final message** in this iteration MUST be a single JSON object — nothing else, no prose, no code fence, no commentary:
+
+```
+{\"natural_stop\": <bool>, \"summary\": \"<one-line summary of what you did this iteration>\"}
+```
+
+- Set `natural_stop` to `true` when the goal is fully reached or no meaningful work remains. The orchestrator will exit the loop cleanly.
+- Set `natural_stop` to `false` after making a small focused change so the diff can be committed and the next iteration can run.
+- The JSON is the *only* signal the orchestrator looks at. Discussing or quoting `natural_stop` in earlier messages is fine — only this final JSON is parsed.
 
 ";
 
@@ -43,8 +52,18 @@ Each invocation of you is one iteration of this task's loop:
 - Use `git log` on the current branch to see what previous iterations of *this* task \
   accomplished — your previous self has no in-process memory across iterations.
 - Any learnings you wrote in earlier iterations appear below under \"Cross-iteration notes\".
-- When the task is fully complete, output the literal token `TASK_COMPLETE` on its own \
-  line and stop. The loop will move on to the next task.
+
+## How to stop
+
+Your **final message** in this iteration MUST be a single JSON object — nothing else, no prose, no code fence, no commentary:
+
+```
+{\"task_complete\": <bool>, \"summary\": \"<one-line summary of what you did this iteration>\"}
+```
+
+- Set `task_complete` to `true` when the task is fully done. The orchestrator will move on to the next task.
+- Set `task_complete` to `false` after making a small focused change so the diff can be committed and the next iteration can run.
+- The JSON is the *only* signal the orchestrator looks at. Discussing or quoting `task_complete` in earlier messages is fine — only this final JSON is parsed.
 
 ";
 
@@ -129,7 +148,7 @@ mod tests {
     fn iteration_prompt_includes_meta_goal_and_iteration() {
         let out = build_iteration_prompt(&parts("ship the thing", 7));
         assert!(out.starts_with("# About this run"));
-        assert!(out.contains("NATURAL_STOP"));
+        assert!(out.contains("\"natural_stop\""));
         assert!(out.contains("## Goal\n\nship the thing"));
         assert!(out.contains("## Iteration 7"));
     }
@@ -187,7 +206,7 @@ mod tests {
     fn task_prompt_includes_meta_body_and_iteration() {
         let out = build_task_prompt(&parts("ignored goal", 3), "wire up X");
         assert!(out.starts_with("# About this run"));
-        assert!(out.contains("TASK_COMPLETE"));
+        assert!(out.contains("\"task_complete\""));
         assert!(out.contains("## Single task\n\nwire up X"));
         assert!(out.contains("## Iteration 3"));
     }
@@ -195,7 +214,7 @@ mod tests {
     #[test]
     fn task_prompt_does_not_use_continuous_meta() {
         let out = build_task_prompt(&parts("g", 1), "task");
-        assert!(!out.contains("NATURAL_STOP"));
+        assert!(!out.contains("\"natural_stop\""));
     }
 
     #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -210,7 +210,7 @@ async fn run_iterations(args: LoopArgs<'_>) -> Result<u32> {
                 consecutive_failures = 0;
                 if out.natural_stop {
                     args.sink
-                        .note("agent reported NATURAL_STOP — exiting cleanly");
+                        .note("agent reported natural_stop — exiting cleanly");
                     break;
                 }
                 git::stage_all(args.repo)?;


### PR DESCRIPTION
Closes #28

## Summary

Replace the substring-based loop termination heuristic with a structured-JSON protocol that the LLM emits only as its final message. Source code, diffs, fixture data, or commentary containing the field names earlier in the response can no longer accidentally end the loop.

## What changed

- **`src/prompt.rs`** — both `META_CONTINUOUS` and `META_ITERATION` are reworded. Instead of "output the literal token `NATURAL_STOP` on its own line", the agent is now instructed to end its **final** message with a single JSON object (`{"natural_stop": <bool>, "summary": "..."}` for continuous, `{"task_complete": <bool>, ...}` for the per-task loop).
- **`src/agent/stream.rs`** — `run_streamed` now remembers the last `AgentEvent::Message` text and feeds *only that* through a new `parse_stop_signal` helper. The helper trims a common code-fence wrapper (` ``` ` or ` ```json `), parses with `serde_json`, and reads `natural_stop` / `task_complete` as booleans. Anything that fails to parse, lacks the field, or carries a non-bool value falls back to `(false, false)` — i.e. "keep going" — which matches the prior "neither sentinel seen" behavior.
- **`src/runner.rs` / `src/iteration.rs` / `src/logger.rs`** — user-facing notes updated from `agent reported NATURAL_STOP` to `agent reported natural_stop` (matching the new field name).

## Why this design

- The control channel and the data channel are now structurally separated. The LLM's prose can mention `natural_stop`, embed JSON in code blocks, or test fixtures containing the literal sentinel — none of it triggers termination unless it lands as the *final* message *and* parses as JSON with the right boolean.
- One extension point. Adding new stop reasons becomes another field on the JSON object, not another `accumulated.contains(...)` line.
- Works identically for both `claude_code` and `codex` — no MCP / tool registration required.
- Conservative failure mode: a malformed final response just keeps the loop running, same as today's "no sentinel" path.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo test --bin kobito` — 180 passed, 0 failed (12 new tests covering `parse_stop_signal` and the end-to-end stream behavior, including a regression for the iteration-11 self-poisoning case)
- [x] `cargo clippy --bin kobito --tests` clean
- [ ] CI green on this branch