### PR TITLE
ci(release): add manual release workflow and changelog generator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,175 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      tag_sha: ${{ steps.tag_sha.outputs.tag_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
+
+      - name: Bump version
+        id: version
+        run: |
+          cargo set-version --bump ${{ github.event.inputs.version_type }}
+          NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "new_version=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: v$NEW_VERSION"
+
+      - name: Run tests
+        run: cargo test --bin kobito
+
+      - name: Create temporary tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
+          git tag ${{ steps.version.outputs.new_version }}
+
+      - name: Generate Changelog
+        run: |
+          chmod +x generate_changelog.sh
+          ./generate_changelog.sh
+
+      - name: Commit changelog and push
+        run: |
+          git add CHANGELOG.md
+          git commit --amend --no-edit
+          git tag -f ${{ steps.version.outputs.new_version }}
+          git push origin main
+          git push origin ${{ steps.version.outputs.new_version }}
+
+      - name: Resolve tag commit SHA
+        id: tag_sha
+        run: |
+          TAG_SHA=$(git rev-list -n 1 ${{ steps.version.outputs.new_version }})
+          echo "tag_sha=$TAG_SHA" >> $GITHUB_OUTPUT
+          echo "Tag commit SHA: $TAG_SHA"
+
+      - name: Extract Release Notes
+        id: extract_notes
+        run: |
+          VERSION=$(echo "${{ steps.version.outputs.new_version }}" | sed 's/^v//')
+          awk "/## \[$VERSION\]/{flag=1; next} /## \[/{flag=0} flag" CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "## What's Changed" > release_notes.md
+            echo "" >> release_notes.md
+            echo "See the full changelog for details." >> release_notes.md
+          fi
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
+          cat release_notes.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.version.outputs.new_version }}
+          name: Release ${{ steps.version.outputs.new_version }}
+          body: ${{ steps.extract_notes.outputs.RELEASE_NOTES }}
+          draft: false
+          prerelease: false
+
+  build-and-upload:
+    name: Build and Upload
+    needs: release
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04-arm
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.new_version }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Create archive (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar -czf ../../../kobito-${{ needs.release.outputs.new_version }}-${{ matrix.target }}.tar.gz kobito
+      - name: Create archive (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          Compress-Archive -Path kobito.exe -DestinationPath ../../../kobito-${{ needs.release.outputs.new_version }}-${{ matrix.target }}.zip
+      - name: Upload Release Asset (Unix)
+        if: matrix.os != 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./kobito-${{ needs.release.outputs.new_version }}-${{ matrix.target }}.tar.gz
+          asset_name: kobito-${{ needs.release.outputs.new_version }}-${{ matrix.target }}.tar.gz
+          asset_content_type: application/gzip
+      - name: Upload Release Asset (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./kobito-${{ needs.release.outputs.new_version }}-${{ matrix.target }}.zip
+          asset_name: kobito-${{ needs.release.outputs.new_version }}-${{ matrix.target }}.zip
+          asset_content_type: application/zip
+
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: [release, build-and-upload]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.new_version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,3 +173,62 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Publish to crates.io
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  update-homebrew:
+    name: Update Homebrew Formula
+    runs-on: ubuntu-latest
+    needs: [release, build-and-upload]
+    steps:
+      - name: Checkout homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: unhappychoice/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update Homebrew formula
+        run: |
+          VERSION=${{ needs.release.outputs.new_version }}
+
+          MACOS_INTEL_URL="https://github.com/unhappychoice/kobito/releases/download/$VERSION/kobito-$VERSION-x86_64-apple-darwin.tar.gz"
+          MACOS_INTEL_SHA=$(curl -sL "$MACOS_INTEL_URL" | sha256sum | cut -d' ' -f1)
+
+          MACOS_ARM_URL="https://github.com/unhappychoice/kobito/releases/download/$VERSION/kobito-$VERSION-aarch64-apple-darwin.tar.gz"
+          MACOS_ARM_SHA=$(curl -sL "$MACOS_ARM_URL" | sha256sum | cut -d' ' -f1)
+
+          LINUX_INTEL_URL="https://github.com/unhappychoice/kobito/releases/download/$VERSION/kobito-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
+          LINUX_INTEL_SHA=$(curl -sL "$LINUX_INTEL_URL" | sha256sum | cut -d' ' -f1)
+
+          LINUX_ARM_URL="https://github.com/unhappychoice/kobito/releases/download/$VERSION/kobito-$VERSION-aarch64-unknown-linux-gnu.tar.gz"
+          LINUX_ARM_SHA=$(curl -sL "$LINUX_ARM_URL" | sha256sum | cut -d' ' -f1)
+
+          echo "Calculated SHAs:"
+          echo "macOS Intel: $MACOS_INTEL_SHA"
+          echo "macOS ARM: $MACOS_ARM_SHA"
+          echo "Linux Intel: $LINUX_INTEL_SHA"
+          echo "Linux ARM: $LINUX_ARM_SHA"
+
+          cd homebrew-tap
+
+          sed -i "s|https://github.com/unhappychoice/kobito/releases/download/v[0-9.]\+/kobito-v[0-9.]\+-x86_64-apple-darwin.tar.gz|$MACOS_INTEL_URL|g" Formula/kobito.rb
+          sed -i "s|https://github.com/unhappychoice/kobito/releases/download/v[0-9.]\+/kobito-v[0-9.]\+-aarch64-apple-darwin.tar.gz|$MACOS_ARM_URL|g" Formula/kobito.rb
+          sed -i "s|https://github.com/unhappychoice/kobito/releases/download/v[0-9.]\+/kobito-v[0-9.]\+-x86_64-unknown-linux-gnu.tar.gz|$LINUX_INTEL_URL|g" Formula/kobito.rb
+          sed -i "s|https://github.com/unhappychoice/kobito/releases/download/v[0-9.]\+/kobito-v[0-9.]\+-aarch64-unknown-linux-gnu.tar.gz|$LINUX_ARM_URL|g" Formula/kobito.rb
+
+          FIRST_SHA_LINE=$(grep -n 'sha256 "' Formula/kobito.rb | head -1 | cut -d: -f1)
+          sed -i "${FIRST_SHA_LINE}s/sha256 \"[a-f0-9]\+\"/sha256 \"$MACOS_INTEL_SHA\"/" Formula/kobito.rb
+
+          SECOND_SHA_LINE=$(grep -n 'sha256 "' Formula/kobito.rb | head -2 | tail -1 | cut -d: -f1)
+          sed -i "${SECOND_SHA_LINE}s/sha256 \"[a-f0-9]\+\"/sha256 \"$MACOS_ARM_SHA\"/" Formula/kobito.rb
+
+          THIRD_SHA_LINE=$(grep -n 'sha256 "' Formula/kobito.rb | head -3 | tail -1 | cut -d: -f1)
+          sed -i "${THIRD_SHA_LINE}s/sha256 \"[a-f0-9]\+\"/sha256 \"$LINUX_INTEL_SHA\"/" Formula/kobito.rb
+
+          FOURTH_SHA_LINE=$(grep -n 'sha256 "' Formula/kobito.rb | head -4 | tail -1 | cut -d: -f1)
+          sed -i "${FOURTH_SHA_LINE}s/sha256 \"[a-f0-9]\+\"/sha256 \"$LINUX_ARM_SHA\"/" Formula/kobito.rb
+
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add Formula/kobito.rb
+          git commit -m "chore: update kobito to $VERSION"
+          git push

--- a/Formula/kobito.rb
+++ b/Formula/kobito.rb
@@ -1,0 +1,37 @@
+class Kobito < Formula
+  desc "Autonomous coding agent orchestrator"
+  homepage "https://github.com/unhappychoice/kobito"
+  license "ISC"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/unhappychoice/kobito/releases/download/v0.0.1/kobito-v0.0.1-x86_64-apple-darwin.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+
+    on_arm do
+      url "https://github.com/unhappychoice/kobito/releases/download/v0.0.1/kobito-v0.0.1-aarch64-apple-darwin.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/unhappychoice/kobito/releases/download/v0.0.1/kobito-v0.0.1-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+
+    on_arm do
+      url "https://github.com/unhappychoice/kobito/releases/download/v0.0.1/kobito-v0.0.1-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "kobito"
+  end
+
+  test do
+    system "#{bin}/kobito", "--version"
+  end
+end

--- a/generate_changelog.sh
+++ b/generate_changelog.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Generate CHANGELOG.md from git commit history
+# Follows Conventional Commits format
+
+set -e
+
+CHANGELOG_FILE="CHANGELOG.md"
+TEMP_FILE="${CHANGELOG_FILE}.tmp"
+
+# Function to generate changelog section for a range of commits
+function generate_section_for_commits() {
+    local from_ref="$1"
+    local to_ref="$2"
+
+    # Build git log range
+    if [ -z "$to_ref" ]; then
+        local range="$from_ref"
+    else
+        local range="${to_ref}..${from_ref}"
+    fi
+
+    # Get commits and categorize them
+    local features=""
+    local fixes=""
+    local breaking=""
+    local others=""
+
+    # Process commits
+    while IFS= read -r commit; do
+        if [ -z "$commit" ]; then
+            continue
+        fi
+
+        local message=$(echo "$commit" | cut -d' ' -f2-)
+        local commit_hash=$(echo "$commit" | cut -d' ' -f1)
+
+        # Get repository URL from git remote
+        local repo_url=$(git remote get-url origin | sed 's/\.git$//' | sed 's/git@github\.com:/https:\/\/github\.com\//')
+
+        # Categorize commit based on conventional commit format
+        case "$message" in
+            feat*|feature*)
+                features="${features}- ${message} ([${commit_hash:0:7}](${repo_url}/commit/${commit_hash}))\n"
+                ;;
+            fix*)
+                fixes="${fixes}- ${message} ([${commit_hash:0:7}](${repo_url}/commit/${commit_hash}))\n"
+                ;;
+            *"BREAKING CHANGE"*|*"!"*)
+                breaking="${breaking}- ${message} ([${commit_hash:0:7}](${repo_url}/commit/${commit_hash}))\n"
+                ;;
+            chore*|docs*|style*|refactor*|test*|build*|ci*)
+                others="${others}- ${message} ([${commit_hash:0:7}](${repo_url}/commit/${commit_hash}))\n"
+                ;;
+            "Merge pull request"*)
+                # Extract PR info
+                local pr_info=$(echo "$message" | sed 's/Merge pull request #\([0-9]*\) from .*/PR #\1/')
+                others="${others}- ${pr_info}: ${message} ([${commit_hash:0:7}](${repo_url}/commit/${commit_hash}))\n"
+                ;;
+            *)
+                others="${others}- ${message} ([${commit_hash:0:7}](${repo_url}/commit/${commit_hash}))\n"
+                ;;
+        esac
+    done < <(git log --oneline --no-merges "$range" 2>/dev/null || true)
+
+    # Output categorized changes
+    local has_content=false
+
+    if [ -n "$breaking" ]; then
+        echo "### 💥 BREAKING CHANGES"
+        echo ""
+        echo -e "$breaking"
+        has_content=true
+    fi
+
+    if [ -n "$features" ]; then
+        echo "### ✨ Features"
+        echo ""
+        echo -e "$features"
+        has_content=true
+    fi
+
+    if [ -n "$fixes" ]; then
+        echo "### 🐛 Bug Fixes"
+        echo ""
+        echo -e "$fixes"
+        has_content=true
+    fi
+
+    if [ -n "$others" ]; then
+        echo "### 📝 Other Changes"
+        echo ""
+        echo -e "$others"
+        has_content=true
+    fi
+
+    if [ "$has_content" = false ]; then
+        echo "- No notable changes"
+        echo ""
+    fi
+
+    echo ""
+}
+
+# Get the current version from Cargo.toml
+CURRENT_VERSION=$(grep "^version" Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+
+# Create header
+cat > "$TEMP_FILE" << EOF
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+EOF
+
+# Get all tags sorted by version (newest first)
+TAGS=$(git tag -l --sort=-version:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | head -20)
+
+# If no tags exist, show unreleased changes
+if [ -z "$TAGS" ]; then
+    echo "## [Unreleased]" >> "$TEMP_FILE"
+    echo "" >> "$TEMP_FILE"
+    generate_section_for_commits "HEAD" "" >> "$TEMP_FILE"
+else
+    # Get latest tag
+    LATEST_TAG=$(echo "$TAGS" | head -1)
+
+    # Check if there are unreleased changes
+    UNRELEASED_COMMITS=$(git log --oneline "${LATEST_TAG}..HEAD" --pretty=format:"%s" | wc -l)
+
+    if [ "$UNRELEASED_COMMITS" -gt 0 ]; then
+        echo "## [Unreleased]" >> "$TEMP_FILE"
+        echo "" >> "$TEMP_FILE"
+        generate_section_for_commits "HEAD" "$LATEST_TAG" >> "$TEMP_FILE"
+    fi
+
+    # Generate sections for each tag
+    PREV_TAG=""
+    TAGS_ARRAY=($TAGS)
+    for i in "${!TAGS_ARRAY[@]}"; do
+        TAG="${TAGS_ARRAY[$i]}"
+        TAG_DATE=$(git log -1 --format="%ai" "$TAG" | cut -d' ' -f1)
+        CLEAN_VERSION=$(echo "$TAG" | sed 's/^v//')
+
+        echo "## [$CLEAN_VERSION] - $TAG_DATE" >> "$TEMP_FILE"
+        echo "" >> "$TEMP_FILE"
+
+        # Get the next (older) tag for the range
+        if [ $((i + 1)) -lt ${#TAGS_ARRAY[@]} ]; then
+            PREV_TAG="${TAGS_ARRAY[$((i + 1))]}"
+        else
+            PREV_TAG=""
+        fi
+
+        generate_section_for_commits "$TAG" "$PREV_TAG" >> "$TEMP_FILE"
+    done
+fi
+
+# Replace the old changelog with the new one
+mv "$TEMP_FILE" "$CHANGELOG_FILE"
+
+echo "✅ CHANGELOG.md has been generated successfully!"
+echo "📄 Preview:"
+echo "----------------------------------------"
+head -20 "$CHANGELOG_FILE"
+echo "----------------------------------------"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+REPO="unhappychoice/kobito"
+BINARY_NAME="kobito"
+
+get_latest_release() {
+    curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+check_glibc_version() {
+    if ! command -v ldd &> /dev/null; then
+        return
+    fi
+
+    GLIBC_VERSION=$(ldd --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+    REQUIRED_VERSION="2.35"
+
+    if [ -n "$GLIBC_VERSION" ]; then
+        if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$GLIBC_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+            echo ""
+            echo "WARNING: Your glibc version ($GLIBC_VERSION) is older than $REQUIRED_VERSION."
+            echo "The pre-built binary may not work on your system."
+            echo ""
+            echo "Options:"
+            echo "  1. Upgrade your OS to get a newer glibc"
+            echo "  2. Build from source: cargo install kobito"
+            echo "  3. Continue anyway and see if it works"
+            echo ""
+            read -p "Continue with installation? [y/N] " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                echo "Installation cancelled."
+                exit 0
+            fi
+        fi
+    fi
+}
+
+detect_platform() {
+    OS="$(uname -s)"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        Linux*)
+            check_glibc_version
+            case "$ARCH" in
+                x86_64)
+                    echo "x86_64-unknown-linux-gnu"
+                    ;;
+                aarch64|arm64)
+                    echo "aarch64-unknown-linux-gnu"
+                    ;;
+                *)
+                    echo "Unsupported architecture: $ARCH" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        Darwin*)
+            case "$ARCH" in
+                x86_64)
+                    echo "x86_64-apple-darwin"
+                    ;;
+                arm64)
+                    echo "aarch64-apple-darwin"
+                    ;;
+                *)
+                    echo "Unsupported architecture: $ARCH" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unsupported OS: $OS" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main() {
+    VERSION="${1:-$(get_latest_release)}"
+    PLATFORM="$(detect_platform)"
+
+    if [ -z "$VERSION" ]; then
+        echo "Failed to detect latest version" >&2
+        exit 1
+    fi
+
+    echo "Installing $BINARY_NAME $VERSION for $PLATFORM..."
+
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/${BINARY_NAME}-${VERSION}-${PLATFORM}.tar.gz"
+    TEMP_DIR="$(mktemp -d)"
+
+    trap 'rm -rf "$TEMP_DIR"' EXIT
+
+    echo "Downloading from $DOWNLOAD_URL..."
+    curl -sL "$DOWNLOAD_URL" | tar xz -C "$TEMP_DIR"
+
+    INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+    mkdir -p "$INSTALL_DIR"
+
+    mv "$TEMP_DIR/$BINARY_NAME" "$INSTALL_DIR/"
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+    echo "Successfully installed $BINARY_NAME to $INSTALL_DIR/$BINARY_NAME"
+    echo ""
+    echo "Make sure $INSTALL_DIR is in your PATH:"
+    echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` with `workflow_dispatch` trigger (`patch` / `minor` / `major` bump) covering version bump, tagging, changelog regeneration, multi-platform builds (linux x86/arm, macOS x86/arm, windows x86), GitHub release creation, and `cargo publish` to crates.io.
- Add `generate_changelog.sh` to rebuild `CHANGELOG.md` from Conventional Commits, mirroring gitlogue's script.
- Skip the flake.nix hash-update and homebrew-tap update jobs from gitlogue's pipeline — kobito does not yet ship a `flake.nix` or a Formula entry, so those would fail. Easy to add later.

## Test plan
- [ ] Add `CARGO_REGISTRY_TOKEN` to repo secrets before the first dispatch.
- [ ] Confirm `Settings → Actions → Workflow permissions` is set to **Read and write**.
- [ ] Trigger the workflow with `version_type=patch` on a throwaway branch / fork to verify version bump → tag → release → asset upload → crates.io publish.
- [ ] Verify the generated `CHANGELOG.md` renders correctly on the GitHub release page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented an automated release workflow with version bumping and testing.
  * Added multi-platform binary builds for Linux (x86_64, aarch64), Windows, and macOS (x86_64, aarch64).
  * Enabled automated changelog generation from commit history.
  * Configured automated crate publishing to crates.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->