### PR TITLE
fix(iter): bail out when an iteration produces no diff

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -113,6 +113,24 @@ pub fn diff_against(repo: &Path, base: &str) -> Result<String> {
     Ok(String::from_utf8(out.stdout)?)
 }
 
+pub fn has_commits_ahead_of(repo: &Path, base: &str) -> Result<bool> {
+    let out = Command::new("git")
+        .current_dir(repo)
+        .args(["rev-list", "--count", &format!("{base}..HEAD")])
+        .output()?;
+    if !out.status.success() {
+        bail!(
+            "git rev-list {base}..HEAD failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let count: u32 = String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0);
+    Ok(count > 0)
+}
+
 pub fn commit(repo: &Path, message: &str) -> Result<()> {
     let out = Command::new("git")
         .current_dir(repo)
@@ -369,6 +387,42 @@ mod tests {
 
         assert!(
             err.contains("git diff missing-base...HEAD failed"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn has_commits_ahead_of_returns_false_when_branch_matches_base() {
+        let repo = init_repo("ahead-equal");
+        empty_commit(&repo, "init");
+        create_and_checkout(&repo, "feature/no-work").unwrap();
+
+        assert!(!has_commits_ahead_of(&repo, "main").unwrap());
+    }
+
+    #[test]
+    fn has_commits_ahead_of_returns_true_when_branch_has_new_commits() {
+        let repo = init_repo("ahead-progress");
+        empty_commit(&repo, "init");
+        create_and_checkout(&repo, "feature/with-work").unwrap();
+        write_file(&repo, "a.txt", "v1\n");
+        stage_all(&repo).unwrap();
+        commit(&repo, "feat: progress").unwrap();
+
+        assert!(has_commits_ahead_of(&repo, "main").unwrap());
+    }
+
+    #[test]
+    fn has_commits_ahead_of_reports_git_stderr_for_unknown_base() {
+        let repo = init_repo("ahead-missing-base");
+        empty_commit(&repo, "init");
+
+        let err = has_commits_ahead_of(&repo, "missing-base")
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("git rev-list missing-base..HEAD failed"),
             "got: {err}"
         );
     }

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -173,8 +173,8 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                         // work, treat the task as complete so the PR can
                         // be opened; otherwise the agent has stalled
                         // before producing anything.
-                        let prior_commits = git::has_commits_ahead_of(&repo, &starting_branch)
-                            .unwrap_or(false);
+                        let prior_commits =
+                            git::has_commits_ahead_of(&repo, &starting_branch).unwrap_or(false);
                         if prior_commits {
                             sink.note(
                                 "no progress this iteration; treating task as complete (commits already on branch)",

--- a/src/iteration.rs
+++ b/src/iteration.rs
@@ -122,7 +122,8 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                 Ok(out) => {
                     consecutive_failures = 0;
                     git::stage_all(&repo)?;
-                    if git::has_staged_changes(&repo)? {
+                    let produced_diff = git::has_staged_changes(&repo)?;
+                    if produced_diff {
                         let diff = git::diff_staged(&repo)?;
                         let style = git::recent_commit_messages(&repo, 20).unwrap_or_default();
                         let msg =
@@ -159,6 +160,31 @@ pub async fn run(args: IterationArgs) -> Result<()> {
                     if out.task_complete {
                         sink.note("agent reported task_complete");
                         completed = true;
+                        break;
+                    }
+                    if !produced_diff {
+                        // Per the prompt contract, every iteration must
+                        // either produce a focused change or set
+                        // task_complete=true. When the agent does
+                        // neither, looping more burns budget on a stalled
+                        // run (the failure mode that previously chewed
+                        // through 20+ iterations before timing out). If
+                        // earlier iterations already committed real
+                        // work, treat the task as complete so the PR can
+                        // be opened; otherwise the agent has stalled
+                        // before producing anything.
+                        let prior_commits = git::has_commits_ahead_of(&repo, &starting_branch)
+                            .unwrap_or(false);
+                        if prior_commits {
+                            sink.note(
+                                "no progress this iteration; treating task as complete (commits already on branch)",
+                            );
+                            completed = true;
+                        } else {
+                            sink.note(
+                                "no progress and no commits on this branch; giving up on this task",
+                            );
+                        }
                         break;
                     }
                 }
@@ -657,6 +683,133 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_bails_after_first_no_diff_iteration_when_branch_has_no_commits() {
+        // Regression for the iter loop chewing through every iteration
+        // when the agent ignores the prompt contract and keeps
+        // returning task_complete=false without producing any diff.
+        // The orchestrator must bail out after one empty iteration so
+        // the budget isn't wasted (see issue: agent loops until
+        // max_iterations).
+        let _guard = ENV_LOCK.lock().await;
+        let old_dir = std::env::current_dir().unwrap();
+        let old_path = std::env::var_os("PATH");
+        let old_xdg = std::env::var_os("XDG_STATE_HOME");
+        let dir = unique_tmp("stall-no-commits");
+        let repo = dir.0.join("repo");
+        let state_home = dir.0.join("state");
+        let backlog = dir.0.join("tasks.md");
+        let bin = dir.0.join("bin");
+
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(&backlog, "- [ ] Stall without progress\n").unwrap();
+        write_fake_codex(&bin);
+        init_repo(&repo);
+
+        set_env("XDG_STATE_HOME", Some(state_home.as_os_str()));
+        set_env(
+            "PATH",
+            Some(prefixed_path(&bin, old_path.as_deref()).as_os_str()),
+        );
+        std::env::set_current_dir(&repo).unwrap();
+
+        let result = run(IterationArgs {
+            backlog: Some(backlog),
+            preset: None,
+            vars: vec![],
+            max_iterations: 5,
+            max_failures: 1,
+            agent: "codex".into(),
+            allow_dirty: false,
+        })
+        .await;
+        let project = single_project_under(&state_home);
+
+        std::env::set_current_dir(old_dir).unwrap();
+        set_env("PATH", old_path.as_deref());
+        set_env("XDG_STATE_HOME", old_xdg.as_deref());
+
+        result.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(state::tasks_path(&project)).unwrap(),
+            "- [ ] Stall without progress\n",
+            "task should remain pending when the agent never produced anything",
+        );
+        assert_iteration_count(&project, 1);
+        let log = run_log(&project);
+        assert!(
+            log.contains("no progress and no commits"),
+            "log should mention the stall reason: {log}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_completes_task_when_iteration_produces_no_diff_after_prior_commit() {
+        // When earlier iterations already committed real work and a
+        // later iteration produces no diff (the common
+        // "task-already-done-but-agent-keeps-running" pattern), the
+        // orchestrator should treat the task as complete and open the
+        // PR rather than burning the rest of the budget.
+        let _guard = ENV_LOCK.lock().await;
+        let old_dir = std::env::current_dir().unwrap();
+        let old_path = std::env::var_os("PATH");
+        let old_xdg = std::env::var_os("XDG_STATE_HOME");
+        let dir = unique_tmp("stall-after-commit");
+        let repo = dir.0.join("repo");
+        let remote = dir.0.join("origin.git");
+        let state_home = dir.0.join("state");
+        let backlog = dir.0.join("tasks.md");
+        let bin = dir.0.join("bin");
+
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(&backlog, "- [ ] Land then stall\n").unwrap();
+        write_progress_then_stall_fake_codex(&bin);
+        write_fake_gh(&bin);
+        init_repo(&repo);
+        std::fs::write(repo.join(".git").join("kobito-test-gh-success"), "").unwrap();
+        init_bare_remote(&remote);
+        run_git(
+            &repo,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+
+        set_env("XDG_STATE_HOME", Some(state_home.as_os_str()));
+        set_env(
+            "PATH",
+            Some(prefixed_path(&bin, old_path.as_deref()).as_os_str()),
+        );
+        std::env::set_current_dir(&repo).unwrap();
+
+        let result = run(IterationArgs {
+            backlog: Some(backlog),
+            preset: None,
+            vars: vec![],
+            max_iterations: 8,
+            max_failures: 1,
+            agent: "codex".into(),
+            allow_dirty: false,
+        })
+        .await;
+        let project = single_project_under(&state_home);
+
+        std::env::set_current_dir(old_dir).unwrap();
+        set_env("PATH", old_path.as_deref());
+        set_env("XDG_STATE_HOME", old_xdg.as_deref());
+
+        result.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(state::tasks_path(&project)).unwrap(),
+            "- [x] Land then stall\n",
+        );
+        assert_branch_exists(&repo, "feature/progress-then-stall-task-1");
+        assert_iteration_count(&project, 2);
+        let log = run_log(&project);
+        assert!(
+            log.contains("treating task as complete"),
+            "log should mention complete-via-stall: {log}"
+        );
+    }
+
+    #[tokio::test]
     async fn run_leaves_completed_task_open_when_pr_creation_fails() {
         let _guard = ENV_LOCK.lock().await;
         let old_dir = std::env::current_dir().unwrap();
@@ -778,6 +931,47 @@ case " $* " in
     ;;
 esac
 "#,
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    fn write_progress_then_stall_fake_codex(bin: &Path) {
+        // First call appends to README so kobito sees a diff and
+        // commits. Subsequent calls leave the tree untouched, modeling
+        // the agent stalling after landing real work — the situation
+        // the orchestrator must detect to short-circuit the loop.
+        let script = bin.join("codex");
+        let marker = bin.join(".kobito-iter-1-done");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+case " $* " in
+  *" --json "*)
+    if [ ! -f __MARKER__ ]; then
+      printf 'first iter work\n' >> README.md
+      : > __MARKER__
+    fi
+    printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"task_complete\":false}"}}'
+    printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5,"cached_input_tokens":6}}'
+    ;;
+  *"Suggest a single git branch name"*)
+    printf '%s\n' 'feature/progress-then-stall'
+    ;;
+  *"Generate a single commit message"*)
+    printf '%s\n' 'test(iteration): partial work'
+    ;;
+  *)
+    printf '%s\n' 'NO_NOTES'
+    ;;
+esac
+"#
+            .replace("__MARKER__", marker.to_str().unwrap()),
         )
         .unwrap();
         #[cfg(unix)]
@@ -936,6 +1130,31 @@ esac
             id,
             root: project_root,
         }
+    }
+
+    fn assert_iteration_count(project: &state::ProjectPaths, expected: usize) {
+        let runs_dir = project.root.join("runs");
+        let prompts_dir = std::fs::read_dir(&runs_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path().join("prompts"))
+            .find(|path| path.exists())
+            .expect("expected a run with a prompts/ directory");
+        let count = std::fs::read_dir(&prompts_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .map(|n| n.starts_with("iter-") && n.ends_with(".md"))
+                    .unwrap_or(false)
+            })
+            .count();
+        assert_eq!(
+            count, expected,
+            "expected exactly {expected} iteration prompt(s) in {prompts_dir:?}",
+        );
     }
 
     fn assert_saved_prompt_mentions_task(project: &state::ProjectPaths, task: &str) {


### PR DESCRIPTION
## Summary

- The prompt-only fix in #42 wasn't enough: even with the new "stop looping on already-completed tasks" wording, agents still return `task_complete: false` while contributing nothing. A user just saw `kobito iter` chew through 22 iterations on a task that landed in iteration 1.
- Enforce the prompt contract on the orchestrator side. Every iteration must either produce a focused change or set `task_complete: true`. When it does neither, the loop now exits immediately:
  - if earlier iterations committed real work → mark the task complete and open the PR (the `4dbf1be already, agent keeps verifying` case),
  - otherwise → the agent stalled before producing anything; leave the branch for inspection.
- Adds `git::has_commits_ahead_of` so the orchestrator can tell those two cases apart.

## Test plan

- [x] `cargo test --bin kobito` (313 passed)
- [x] `cargo build --release`
- [x] `cargo clippy --bin kobito`
- [x] New: `iteration::tests::run_bails_after_first_no_diff_iteration_when_branch_has_no_commits` — high `max_iterations`, fake agent that never produces a diff; asserts only one iteration ran and the stall reason was logged.
- [x] New: `iteration::tests::run_completes_task_when_iteration_produces_no_diff_after_prior_commit` — fake agent commits in iter 1, stalls in iter 2; asserts the task is marked complete, branch exists, PR is opened, only two iterations ran.
- [x] New: `git::tests::has_commits_ahead_of_*` covering the equal / ahead / unknown-base cases.